### PR TITLE
COMMUNITY REVIEW: implement queue for requests to bundled AuthProvider implementations

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -14,6 +14,7 @@ export { TokenInfo } from './TokenInfo';
 export type { TokenInfoData } from './TokenInfo';
 
 export type { AuthProvider, AuthProviderTokenType } from './providers/AuthProvider';
+export { BaseAuthProvider } from './providers/BaseAuthProvider';
 export { ClientCredentialsAuthProvider } from './providers/ClientCredentialsAuthProvider';
 export { RefreshingAuthProvider } from './providers/RefreshingAuthProvider';
 export type { RefreshConfig } from './providers/RefreshingAuthProvider';

--- a/packages/auth/src/providers/BaseAuthProvider.ts
+++ b/packages/auth/src/providers/BaseAuthProvider.ts
@@ -1,0 +1,72 @@
+import type { AccessToken } from '../AccessToken';
+import type { AuthProvider, AuthProviderTokenType } from './AuthProvider';
+
+export abstract class BaseAuthProvider implements AuthProvider {
+	abstract clientId: string;
+	abstract tokenType: AuthProviderTokenType;
+	abstract currentScopes: string[];
+
+	private _newTokenScopes = new Set<string>();
+	private _newTokenPromise: Promise<AccessToken | null> | null = null;
+	private _queuedScopes = new Set<string>();
+	private _queueExecutor: (() => void) | null = null;
+	private _queuePromise: Promise<AccessToken | null> | null = null;
+
+	async getAccessToken(scopes?: string[]): Promise<AccessToken | null> {
+		if (this._newTokenPromise) {
+			if (!scopes || scopes.every(scope => this._newTokenScopes.has(scope))) {
+				return await this._newTokenPromise;
+			}
+
+			if (this._queueExecutor) {
+				for (const scope of scopes) {
+					this._queuedScopes.add(scope);
+				}
+			} else {
+				this._queuedScopes = new Set<string>(scopes);
+			}
+
+			this._queuePromise ??= new Promise<AccessToken | null>((resolve, reject) => {
+				this._queueExecutor = async () => {
+					if (!this._queuePromise) {
+						return;
+					}
+					this._newTokenScopes = this._queuedScopes;
+					this._queuedScopes = new Set<string>();
+					this._newTokenPromise = this._queuePromise;
+					this._queuePromise = null;
+					this._queueExecutor = null;
+					try {
+						resolve(await this._doGetAccessToken(Array.from(this._newTokenScopes)));
+					} catch (e) {
+						reject(e);
+					} finally {
+						this._newTokenPromise = null;
+						this._newTokenScopes = new Set<string>();
+						(this._queueExecutor as (() => void) | null)?.();
+					}
+				};
+			});
+
+			return await this._queuePromise;
+		}
+
+		this._newTokenScopes = new Set<string>(scopes ?? []);
+		this._newTokenPromise = new Promise<AccessToken | null>(async (resolve, reject) => {
+			try {
+				const scopesToFetch = Array.from(this._newTokenScopes);
+				resolve(await this._doGetAccessToken(scopesToFetch));
+			} catch (e) {
+				reject(e);
+			} finally {
+				this._newTokenPromise = null;
+				this._newTokenScopes = new Set<string>();
+				this._queueExecutor?.();
+			}
+		});
+
+		return await this._newTokenPromise;
+	}
+
+	protected abstract _doGetAccessToken(scopes?: string[]): Promise<AccessToken | null>;
+}

--- a/packages/auth/src/providers/ClientCredentialsAuthProvider.ts
+++ b/packages/auth/src/providers/ClientCredentialsAuthProvider.ts
@@ -3,13 +3,14 @@ import { rtfm } from '@twurple/common';
 import type { AccessToken } from '../AccessToken';
 import { accessTokenIsExpired } from '../AccessToken';
 import { getAppToken } from '../helpers';
-import type { AuthProvider, AuthProviderTokenType } from './AuthProvider';
+import type { AuthProviderTokenType } from './AuthProvider';
+import { BaseAuthProvider } from './BaseAuthProvider';
 
 /**
  * An auth provider that retrieve tokens using client credentials.
  */
 @rtfm<ClientCredentialsAuthProvider>('auth', 'ClientCredentialsAuthProvider', 'clientId')
-export class ClientCredentialsAuthProvider implements AuthProvider {
+export class ClientCredentialsAuthProvider extends BaseAuthProvider {
 	private readonly _clientId: string;
 	@Enumerable(false) private readonly _clientSecret: string;
 	@Enumerable(false) private _token?: AccessToken;
@@ -28,29 +29,9 @@ export class ClientCredentialsAuthProvider implements AuthProvider {
 	 * @param clientSecret The client secret of your application.
 	 */
 	constructor(clientId: string, clientSecret: string) {
+		super();
 		this._clientId = clientId;
 		this._clientSecret = clientSecret;
-	}
-
-	/**
-	 * Retrieves an access token.
-	 *
-	 * If any scopes are provided, this throws. The client credentials flow does not support scopes.
-	 *
-	 * @param scopes The requested scopes.
-	 */
-	async getAccessToken(scopes?: string[]): Promise<AccessToken> {
-		if (scopes && scopes.length > 0) {
-			throw new Error(
-				`Scope ${scopes.join(', ')} requested but the client credentials flow does not support scopes`
-			);
-		}
-
-		if (!this._token || accessTokenIsExpired(this._token)) {
-			return await this.refresh();
-		}
-
-		return this._token;
 	}
 
 	/**
@@ -72,5 +53,26 @@ export class ClientCredentialsAuthProvider implements AuthProvider {
 	 */
 	get currentScopes(): string[] {
 		return [];
+	}
+
+	/**
+	 * Retrieves an access token.
+	 *
+	 * If any scopes are provided, this throws. The client credentials flow does not support scopes.
+	 *
+	 * @param scopes The requested scopes.
+	 */
+	protected async _doGetAccessToken(scopes?: string[]): Promise<AccessToken> {
+		if (scopes && scopes.length > 0) {
+			throw new Error(
+				`Scope ${scopes.join(', ')} requested but the client credentials flow does not support scopes`
+			);
+		}
+
+		if (!this._token || accessTokenIsExpired(this._token)) {
+			return await this.refresh();
+		}
+
+		return this._token;
 	}
 }


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Improvement
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #318 

<!-- Here you can explain in further detail what your pull request contains. -->

This adds a new abstract base class called `BaseAuthProvider` that handles deduplication/queueing of requests, preventing multiple calls at once.
It then extends this class in all bundled `AuthProvider` implementations except `StaticAuthProvider` (which doesn't do any requests outside of the scope fetching).

I sent this PR to myself so that *other* people can review it. I tested a bunch of possible race conditions already, but I feel like there might still be some. Also, this feels too hacky anyway. Maybe someone has a good idea for refactoring this.

I know that the class doesn't have any doc comments yet. Please don't take this into account in your review - I'll be working on it when I can.