### PR TITLE
Implemented the 'channel:manage:broadcast' scope

### DIFF
--- a/packages/api/src/ApiClient.ts
+++ b/packages/api/src/ApiClient.ts
@@ -46,6 +46,11 @@ export interface ApiConfig {
 	authProvider: AuthProvider;
 
 	/**
+	 * Whether or not to use the new channel:manage:broadcast scope
+	 */
+	useNewBroadcastScope?: boolean;
+
+	/**
 	 * Additional options to pass to the fetch method.
 	 */
 	fetchOptions?: TwitchApiCallFetchOptions;
@@ -340,6 +345,11 @@ export class ApiClient {
 	/** @private */
 	get _authProvider(): AuthProvider {
 		return this._config.authProvider;
+	}
+
+	/** @private */
+	get _useNewBroadcastScope(): boolean {
+		return this._config.useNewBroadcastScope ?? false;
 	}
 
 	private async _callApiInternal(options: TwitchApiCallOptions, clientId?: string, accessToken?: string) {

--- a/packages/api/src/api/helix/channel/HelixChannelApi.ts
+++ b/packages/api/src/api/helix/channel/HelixChannelApi.ts
@@ -73,11 +73,12 @@ export class HelixChannelApi extends BaseApi {
 	 */
 	async updateChannelInfo(user: UserIdResolvable, data: HelixChannelUpdate): Promise<void> {
 		const userId = extractUserId(user);
+		const scope = this._client._useNewBroadcastScope ? 'channel:manage:broadcast' : 'user:edit:broadcast';
 		await this._client.callApi({
 			type: 'helix',
 			url: 'channels',
 			method: 'PATCH',
-			scope: 'user:edit:broadcast',
+			scope: scope,
 			query: {
 				broadcaster_id: userId
 			},

--- a/packages/api/src/api/helix/stream/HelixStreamApi.ts
+++ b/packages/api/src/api/helix/stream/HelixStreamApi.ts
@@ -216,12 +216,13 @@ export class HelixStreamApi extends BaseApi {
 	 * @param description The description of the marker.
 	 */
 	async createStreamMarker(broadcaster: UserIdResolvable, description?: string): Promise<HelixStreamMarker> {
+		const scope = this._client._useNewBroadcastScope ? 'channel:manage:broadcast' : 'user:edit:broadcast';
 		try {
 			const result = await this._client.callApi<HelixResponse<HelixStreamMarkerData>>({
 				url: 'streams/markers',
 				method: 'POST',
 				type: 'helix',
-				scope: 'user:edit:broadcast',
+				scope: scope,
 				query: {
 					user_id: extractUserId(broadcaster),
 					description
@@ -262,10 +263,11 @@ export class HelixStreamApi extends BaseApi {
 	 * @param tagIds The tags to set. If not given, removes all tags.
 	 */
 	async replaceStreamTags(broadcaster: UserIdResolvable, tagIds?: string[]): Promise<void> {
+		const scope = this._client._useNewBroadcastScope ? 'channel:manage:broadcast' : 'user:edit:broadcast';
 		await this._client.callApi({
 			type: 'helix',
 			url: 'streams/tags',
-			scope: 'user:edit:broadcast',
+			scope: scope,
 			method: 'PUT',
 			query: {
 				broadcaster_id: extractUserId(broadcaster)


### PR DESCRIPTION
Type: Improvement

Fixes: #323 

As issue #323 states, Twitch updated their API documentation a year ago to state that the "user:edit:broadcast" scope was replaced with the "channel:manage:broadcast". This PR aims at providing the possibility of passing an argument to the `ApiClient` to use it. 

This adds a `useNewBroadcastScope` boolean to the `ApiConfig` object that is used in that constructor, which alters the behaviour of the 3 relevant methods (`updateChannelInfo`, `createStreamMarker` and `replaceStreamTags`).