### PR TITLE
Bugfix: auth documentation links

### DIFF
--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -6,9 +6,9 @@ Twurple uses a concept named **Authentication Providers** to provide different k
 
 You can choose between different ways to authenticate:
 
-- To only ever use a single token determined at instantiation time, check out [Using a fixed token](/docs/auth/providers/static).  
+- To only ever use a single token determined at instantiation time, check out [Using a fixed token](/docs/auth/providers/static.md).  
   (This is mostly useful for quick prototyping and **not suitable for production apps**.)
-- If you want to run something more long-term, you may be interested in [auto-refreshing tokens](/docs/auth/providers/refreshing).
-- If you run an application that doesn't need user-specific data (or for **EventSub**), you can use [app tokens](/docs/auth/providers/client-credentials).
-- If you are building an Electron app, you can use our premade [Electron auth provider](/docs/auth/providers/electron).
+- If you want to run something more long-term, you may be interested in [auto-refreshing tokens](/docs/auth/providers/refreshing.md).
+- If you run an application that doesn't need user-specific data (or for **EventSub**), you can use [app tokens](/docs/auth/providers/client-credentials.md).
+- If you are building an Electron app, you can use our premade [Electron auth provider](/docs/auth/providers/electron.md).
 - If you have special requirements, you can write your own provider by following the {@AuthProvider} interface.


### PR DESCRIPTION
Type: Bugfix
Fixes: #346

I found the links were missing the Markdown extension. Without it, they report as bad links so I've updated the missing extension, now they seem to work fine.