### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/api-call/src/errors/HttpStatusCodeError.ts
+++ b/packages/api-call/src/errors/HttpStatusCodeError.ts
@@ -15,7 +15,7 @@ export class HttpStatusCodeError extends CustomError {
 	) {
 		super(
 			`Encountered HTTP status code ${_statusCode}: ${statusText}\n\nURL: ${_url}\nMethod: ${_method}\nBody:\n${
-				!isJson && _body.length > 150 ? `${_body.substr(0, 147)}...` : _body
+				!isJson && _body.length > 150 ? `${_body.slice(0, 147)}...` : _body
 			}`
 		);
 	}

--- a/packages/auth-electron/src/ElectronAuthProvider.ts
+++ b/packages/auth-electron/src/ElectronAuthProvider.ts
@@ -138,7 +138,7 @@ export class ElectronAuthProvider extends BaseAuthProvider {
 						}
 					}
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-					const params: Record<string, string> = url.hash ? parse(url.hash.substr(1)) : url.searchParams;
+					const params: Record<string, string> = url.hash ? parse(url.hash.slice(1)) : url.searchParams;
 
 					if (params.error || params.access_token) {
 						done = true;

--- a/packages/chat/src/ChatClient.ts
+++ b/packages/chat/src/ChatClient.ts
@@ -1532,7 +1532,7 @@ export class ChatClient extends IrcClient {
 				}
 
 				default: {
-					if (!messageType || messageType.substr(0, 6) !== 'usage_') {
+					if (!messageType || !messageType.startsWith('usage_')) {
 						this._chatLogger.warn(`Unrecognized notice ID: '${messageType}'`);
 					}
 				}

--- a/packages/common/src/emotes/BaseCheermoteList.ts
+++ b/packages/common/src/emotes/BaseCheermoteList.ts
@@ -121,7 +121,7 @@ export abstract class BaseCheermoteList<DataType> extends DataObject<DataType> {
 				result.push({
 					name,
 					amount,
-					position: utf8Length(message.substr(0, match.index)),
+					position: utf8Length(message.slice(0, match.index)),
 					length: match[0].length,
 					displayInfo: this.getCheermoteDisplayInfo(name, amount, format)
 				});
@@ -155,7 +155,7 @@ export abstract class BaseCheermoteList<DataType> extends DataObject<DataType> {
 		}
 
 		if (currentPosition < message.length) {
-			result.push(message.substr(currentPosition));
+			result.push(message.slice(currentPosition));
 		}
 
 		return result;

--- a/packages/easy-bot/src/BotCommand.ts
+++ b/packages/easy-bot/src/BotCommand.ts
@@ -17,7 +17,7 @@ export abstract class BotCommand {
 		if (!command.startsWith(prefix)) {
 			return null;
 		}
-		command = command.substr(prefix.length);
+		command = command.slice(prefix.length);
 		if (command === this.name || this.aliases.includes(command)) {
 			return params;
 		}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.