### PR TITLE
Update for EventSub changes from 2022‑05‑17

### DIFF
--- a/packages/eventsub/src/events/EventSubChannelBanEvent.ts
+++ b/packages/eventsub/src/events/EventSubChannelBanEvent.ts
@@ -14,6 +14,7 @@ export interface EventSubChannelBanEventData {
 	moderator_user_login: string;
 	moderator_user_name: string;
 	reason: string;
+	banned_at: string;
 	ends_at: string | null;
 	is_permanent: boolean;
 }
@@ -120,6 +121,13 @@ export class EventSubChannelBanEvent extends DataObject<EventSubChannelBanEventD
 	 */
 	get reason(): string {
 		return this[rawDataSymbol].reason;
+	}
+
+	/**
+	 * The date and time when the user was banned or put in a timeout.
+	 */
+	get startDate(): Date {
+		return new Date(this[rawDataSymbol].banned_at);
 	}
 
 	/**

--- a/packages/eventsub/src/events/EventSubChannelHypeTrainBeginEvent.ts
+++ b/packages/eventsub/src/events/EventSubChannelHypeTrainBeginEvent.ts
@@ -10,6 +10,7 @@ export interface EventSubChannelHypeTrainBeginEventData {
 	broadcaster_user_id: string;
 	broadcaster_user_login: string;
 	broadcaster_user_name: string;
+	level: number;
 	total: number;
 	progress: number;
 	goal: number;
@@ -65,6 +66,13 @@ export class EventSubChannelHypeTrainBeginEvent extends DataObject<EventSubChann
 	 */
 	async getBroadcaster(): Promise<HelixUser> {
 		return (await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id))!;
+	}
+
+	/**
+	 * The level the Hype Train started on.
+	 */
+	get level(): number {
+		return this[rawDataSymbol].level;
 	}
 
 	/**

--- a/packages/eventsub/src/events/EventSubUserUpdateEvent.ts
+++ b/packages/eventsub/src/events/EventSubUserUpdateEvent.ts
@@ -8,6 +8,7 @@ export interface EventSubUserUpdateEventData {
 	user_login: string;
 	user_name: string;
 	email?: string;
+	email_verified: boolean;
 	description: string;
 }
 
@@ -60,6 +61,16 @@ export class EventSubUserUpdateEvent extends DataObject<EventSubUserUpdateEventD
 	 */
 	get userEmail(): string | null {
 		return this[rawDataSymbol].email ?? null;
+	}
+
+	/**
+	 * Whether the user's email address has been verified by Twitch.
+	 *
+	 * This is `null` if you are not authorized to read the email address,
+	 * i.e. you have never successfully requested the scope `user:read:email` from the user.
+	 */
+	get userEmailIsVerified(): boolean | null {
+		return this[rawDataSymbol].email ? this[rawDataSymbol].email_verified : null;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Improvement
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: Mentioned on Discord

<!-- Here you can explain in further detail what your pull request contains. -->

### EventSubChannelBanEvent
Matching similar events by calling it `startDate` instead of `bannedDate` so it's also ambiguous between ban and timeout.

### EventSubUserUpdateEvent:
As I've written it, `event.userEmailIsVerified` (`eventData.email_verified`) will be _`null`_ when `eventData.email` is an _empty string_, as per [Twitch documentation](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#user-update-event). `event.userEmail` uses `??` as if `eventData.email` could be _`undefined`_ (missing) but the Twitch documentation says it should be an _empty string_ even if you don't have the email scope. I'd expect to get _`null`_ from `event.userEmail` if `eventData.email` is an _empty string_ judging by Twurple documentation/typing. If you don't want to make that change (`??` -> `||` maybe or a ternary) then maybe `event.userEmailIsVerified` should just always be a _boolean_ to match the event data or I could submit a bugfix.

### EventSubChannelHypeTrainBeginEvent
Added `level`. 👍 