### PR TITLE
Add ban/unban moderation API endpoints

### DIFF
--- a/packages/api/src/api/helix/moderation/HelixBanUser.ts
+++ b/packages/api/src/api/helix/moderation/HelixBanUser.ts
@@ -11,7 +11,7 @@ export interface HelixBanUserData {
 /**
  * Information about a user who has been banned/timed out.
  */
-@rtfm<HelixBanUser>('api', 'HelixBanUserRequest', 'userId')
+@rtfm<HelixBanUser>('api', 'HelixBanUser', 'userId')
 export class HelixBanUser extends DataObject<HelixBanUserData> {
 	/**
 	 * The ID of the broadcaster whose chat room the user was banned/timed out from chatting in.

--- a/packages/api/src/api/helix/moderation/HelixBanUser.ts
+++ b/packages/api/src/api/helix/moderation/HelixBanUser.ts
@@ -1,0 +1,43 @@
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+
+/** @private */
+export interface HelixBanUserData {
+	broadcaster_id: string;
+	end_time: string;
+	moderator_id: string;
+	user_id: string;
+}
+
+/**
+ * Information about a user who has been banned/timed out.
+ */
+@rtfm<HelixBanUser>('api', 'HelixBanUserRequest', 'userId')
+export class HelixBanUser extends DataObject<HelixBanUserData> {
+	/**
+	 * The ID of the broadcaster whose chat room the user was banned/timed out from chatting in.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_id;
+	}
+
+	/**
+	 * The UTC date and time (in RFC3339 format) that the timeout will end. Is null if the user was banned instead of put in a timeout.
+	 */
+	get endTime(): string {
+		return this[rawDataSymbol].end_time;
+	}
+
+	/**
+	 * The ID of the moderator that banned or put the user in the timeout.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].moderator_id;
+	}
+
+	/**
+	 * The ID of the user that was banned or was put in a timeout.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+}

--- a/packages/api/src/api/helix/moderation/HelixModerationApi.ts
+++ b/packages/api/src/api/helix/moderation/HelixModerationApi.ts
@@ -57,6 +57,9 @@ export interface HelixCheckAutoModStatusData {
 
 export type HelixAutoModSettingsUpdate = Exclude<HelixAutoModSettings, 'broadcasterId' | 'moderatorId'>;
 
+/**
+ * Information about a user to be banned/timed out from a channel.
+ */
 export interface HelixBanUserRequest {
 	/**
 	 * The duration (in seconds) that the user should be timed out. If this value is null, the user will be banned.
@@ -312,7 +315,10 @@ export class HelixModerationApi extends BaseApi {
 	 * @param broadcasterId The ID of the broadcaster in whose channel the user will be banned/timed out.
 	 * @param moderatorId The ID of a user that has permission to ban/timeout users in the broadcaster's chat room.
 	 * This must match the user ID associated with the user OAuth token.
-	 * @param data The data about the ban/timeout. Don't use the "data" wrapper.
+	 * @param data
+	 *
+	 * @expandParams
+	 *
 	 * @returns The result data from the ban/timeout request.
 	 */
 	async banUser(

--- a/packages/api/src/api/helix/moderation/HelixModerationApi.ts
+++ b/packages/api/src/api/helix/moderation/HelixModerationApi.ts
@@ -61,7 +61,7 @@ export interface HelixBanUserRequest {
 	/**
 	 * The duration (in seconds) that the user should be timed out. If this value is null, the user will be banned.
 	 */
-	duration: number | null;
+	duration?: number;
 
 	/**
 	 * The reason why the user is being timed out/banned.
@@ -312,8 +312,7 @@ export class HelixModerationApi extends BaseApi {
 	 * @param broadcasterId The ID of the broadcaster in whose channel the user will be banned/timed out.
 	 * @param moderatorId The ID of a user that has permission to ban/timeout users in the broadcaster's chat room.
 	 * This must match the user ID associated with the user OAuth token.
-	 * @param data The data about the ban/timeout, including the user's ID, the reason, and the duration (for timeouts only).
-	 * Don't use the "data" wrapper.
+	 * @param data The data about the ban/timeout. Don't use the "data" wrapper.
 	 * @returns The result data from the ban/timeout request.
 	 */
 	async banUser(

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -93,9 +93,14 @@ export { HelixHypeTrainEvent } from './api/helix/hypeTrain/HelixHypeTrainEvent';
 export type { HelixHypeTrainEventData, HelixHypeTrainEventType } from './api/helix/hypeTrain/HelixHypeTrainEvent';
 
 export { HelixModerationApi } from './api/helix/moderation/HelixModerationApi';
-export type { HelixBanFilter, HelixModeratorFilter } from './api/helix/moderation/HelixModerationApi';
+export type {
+	HelixBanFilter,
+	HelixModeratorFilter,
+	HelixBanUserRequest
+} from './api/helix/moderation/HelixModerationApi';
 export { HelixBan } from './api/helix/moderation/HelixBan';
 export { HelixModerator } from './api/helix/moderation/HelixModerator';
+export { HelixBanUser } from './api/helix/moderation/HelixBanUser';
 
 export { HelixPollApi } from './api/helix/poll/HelixPollApi';
 export type { HelixCreatePollData } from './api/helix/poll/HelixPollApi';


### PR DESCRIPTION
Type: Feature

Fixes: Part of #314

Continues work on the new moderation API endpoints. Adds the new ban/unban user functions.
