### PR TITLE
Add blocked terms to moderation API

### DIFF
--- a/packages/api/src/api/helix/moderation/HelixBanUser.ts
+++ b/packages/api/src/api/helix/moderation/HelixBanUser.ts
@@ -23,7 +23,7 @@ export class HelixBanUser extends DataObject<HelixBanUserData> {
 	/**
 	 * The date and time that the timeout will end. Is `null` if the user was banned instead of put in a timeout.
 	 */
-	get endTime(): Date | null {
+	get endDate(): Date | null {
 		return this[rawDataSymbol].end_time ? new Date(this[rawDataSymbol].end_time) : null;
 	}
 

--- a/packages/api/src/api/helix/moderation/HelixBanUser.ts
+++ b/packages/api/src/api/helix/moderation/HelixBanUser.ts
@@ -21,10 +21,10 @@ export class HelixBanUser extends DataObject<HelixBanUserData> {
 	}
 
 	/**
-	 * The UTC date and time (in RFC3339 format) that the timeout will end. Is null if the user was banned instead of put in a timeout.
+	 * The date and time that the timeout will end. Is `null` if the user was banned instead of put in a timeout.
 	 */
-	get endTime(): string {
-		return this[rawDataSymbol].end_time;
+	get endTime(): Date | null {
+		return this[rawDataSymbol].end_time ? new Date(this[rawDataSymbol].end_time) : null;
 	}
 
 	/**

--- a/packages/api/src/api/helix/moderation/HelixBlockedTerm.ts
+++ b/packages/api/src/api/helix/moderation/HelixBlockedTerm.ts
@@ -1,0 +1,67 @@
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+
+/** @private */
+export interface HelixBlockedTermData {
+	broadcaster_id: string;
+	created_at: string;
+	expires_at: string;
+	id: string;
+	moderator_id: string;
+	text: string;
+	updated_at: string;
+}
+
+/**
+ * Information about a word or phrase blocked in a broadcaster's channel.
+ */
+@rtfm<HelixBlockedTerm>('api', 'HelixBlockedTerm', 'id')
+export class HelixBlockedTerm extends DataObject<HelixBlockedTermData> {
+	/**
+	 * The ID of the broadcaster that owns the list of blocked terms.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_id;
+	}
+
+	/**
+	 * The UTC date and time (in RFC3339 format) of when the term was blocked.
+	 */
+	get createdAt(): string {
+		return this[rawDataSymbol].created_at;
+	}
+
+	/**
+	 * The UTC date and time (in RFC3339 format) of when the blocked term is set to expire. After the block expires, users will be able to use the term in the broadcaster’s chat room.
+	 */
+	get expiresAt(): string {
+		return this[rawDataSymbol].expires_at;
+	}
+
+	/**
+	 * An ID that uniquely identifies this blocked term.
+	 */
+	get id(): string {
+		return this[rawDataSymbol].id;
+	}
+
+	/**
+	 * The ID of the moderator that blocked the word or phrase from being used in the broadcaster’s chat room.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].moderator_id;
+	}
+
+	/**
+	 * The blocked word or phrase.
+	 */
+	get text(): string {
+		return this[rawDataSymbol].text;
+	}
+
+	/**
+	 * The UTC date and time (in RFC3339 format) of when the term was updated.
+	 */
+	get updatedAt(): string {
+		return this[rawDataSymbol].updated_at;
+	}
+}

--- a/packages/api/src/api/helix/moderation/HelixBlockedTerm.ts
+++ b/packages/api/src/api/helix/moderation/HelixBlockedTerm.ts
@@ -24,17 +24,18 @@ export class HelixBlockedTerm extends DataObject<HelixBlockedTermData> {
 	}
 
 	/**
-	 * The UTC date and time (in RFC3339 format) of when the term was blocked.
+	 * The date and time of when the term was blocked.
 	 */
-	get createdAt(): string {
-		return this[rawDataSymbol].created_at;
+	get creationDate(): Date {
+		return new Date(this[rawDataSymbol].created_at);
 	}
 
 	/**
-	 * The UTC date and time (in RFC3339 format) of when the blocked term is set to expire. After the block expires, users will be able to use the term in the broadcaster’s chat room.
+	 * The date and time of when the blocked term is set to expire. After the block expires, users will be able to use the term in the broadcaster’s chat room.
+	 * Is `null` if the term was added manually or permanently blocked by AutoMod.
 	 */
-	get expiresAt(): string {
-		return this[rawDataSymbol].expires_at;
+	get expirationDate(): Date | null {
+		return this[rawDataSymbol].expires_at ? new Date(this[rawDataSymbol].expires_at) : null;
 	}
 
 	/**
@@ -59,9 +60,9 @@ export class HelixBlockedTerm extends DataObject<HelixBlockedTermData> {
 	}
 
 	/**
-	 * The UTC date and time (in RFC3339 format) of when the term was updated.
+	 * The date and time of when the term was updated.
 	 */
-	get updatedAt(): string {
-		return this[rawDataSymbol].updated_at;
+	get updatedDate(): Date {
+		return new Date(this[rawDataSymbol].updated_at);
 	}
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -101,6 +101,7 @@ export type {
 export { HelixBan } from './api/helix/moderation/HelixBan';
 export { HelixModerator } from './api/helix/moderation/HelixModerator';
 export { HelixBanUser } from './api/helix/moderation/HelixBanUser';
+export { HelixBlockedTerm } from './api/helix/moderation/HelixBlockedTerm';
 
 export { HelixPollApi } from './api/helix/poll/HelixPollApi';
 export type { HelixCreatePollData } from './api/helix/poll/HelixPollApi';


### PR DESCRIPTION
Type: Feature

Fixes: #314

This adds support for getting, adding, and removing blocked terms from a channel. This, combined with #326 and #361, should be the remainder of the new moderation API endpoints.
