### PR TITLE
fix(api): pass create stream marker params to body

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
 /packages/*/es
 /packages/*/lib
+*.tsbuildinfo
 .eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,8 +142,13 @@ const namingConvention = [...baseRules.rules['@typescript-eslint/naming-conventi
 	return rule;
 });
 
+const useTypeInfo = !process.env.DF_ESLINT_NO_TYPE_INFO;
+
 module.exports = {
 	extends: ['@d-fischer'],
+	parserOptions: {
+		project: useTypeInfo ? 'tsconfig.base.json' : undefined
+	},
 	rules: {
 		'@typescript-eslint/naming-convention': namingConvention
 	},

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ generatedDocs
 /packages/*/lib
 /packages/*/docs.json
 /docs*.json
+*.tsbuildinfo
 
 # Logs
 logs

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 /packages/*/docs.json
 *.sh
 *.md
+*.tsbuildinfo
 package.json
 /docs*.json
 /generatedDocs

--- a/docs/getting-data/index.md
+++ b/docs/getting-data/index.md
@@ -50,24 +50,24 @@ should use for which use case.
 
 ## Events
 
-| Event type                        | `@twurple/api` | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub`                            |
-|-----------------------------------|----------------|------------------------------|---------------------------|------------------------------------------------|
-| Chat messages                     | No             | Yes                          | Sub & cheer messages only | Sub & cheer messages only                      |
-| Chat mode (e.g. sub only) changes | No             | Yes                          | No                        | No                                             |
-| Whispers                          | No             | Yes                          | Yes                       | No                                             |
-| Cheers                            | No             | Yes                          | Yes                       | Yes                                            |
-| Channel points                    | No             | Redemptions w/ messages only | Redemptions only          | Yes                                            |
-| Subscriptions                     | No             | Published only               | Published only            | Yes                                            |
-| AutoMod                           | No             | No                           | Yes                       | No                                             |
-| Live / offline / stream changes   | No             | No                           | No                        | Yes                                            |
-| Follows                           | No             | No                           | No                        | Yes                                            |
-| Hosts                             | No             | Yes                          | No                        | No                                             |
-| Raids                             | No             | Yes                          | No                        | Yes                                            |
-| Bans                              | No             | Yes                          | Yes                       | Yes                                            |
-| Mod add/remove                    | No             | No                           | Yes                       | Yes                                            |
-| Polls & predictions               | No             | No                           | No                        | Yes                                            |
-| Extension transactions            | No             | No                           | No                        | Yes                                            |
-| Hype Trains                       | History only   | No                           | No                        | Yes                                            |
-| Authorization                     | No             | No                           | No                        | Partial (WIP, more events supported by Twitch) |
-| Drops                             | No             | No                           | No                        | No (supported by Twitch)                       |
-| Additional concerns               | -              | -                            | -                         | As of now, must have a public server           | 
+| Event type                        | `@twurple/api` | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub`                  |
+|-----------------------------------|----------------|------------------------------|---------------------------|--------------------------------------|
+| Chat messages                     | No             | Yes                          | Sub & cheer messages only | Sub & cheer messages only            |
+| Chat mode (e.g. sub only) changes | No             | Yes                          | No                        | No                                   |
+| Whispers                          | No             | Yes                          | Yes                       | No                                   |
+| Cheers                            | No             | Yes                          | Yes                       | Yes                                  |
+| Channel points                    | No             | Redemptions w/ messages only | Redemptions only          | Yes                                  |
+| Subscriptions                     | No             | Published only               | Published only            | Yes                                  |
+| AutoMod                           | No             | No                           | Yes                       | No                                   |
+| Live / offline / stream changes   | No             | No                           | No                        | Yes                                  |
+| Follows                           | No             | No                           | No                        | Yes                                  |
+| Hosts                             | No             | Yes                          | No                        | No                                   |
+| Raids                             | No             | Yes                          | No                        | Yes                                  |
+| Bans                              | No             | Yes                          | Yes                       | Yes                                  |
+| Mod add/remove                    | No             | No                           | Yes                       | Yes                                  |
+| Polls & predictions               | No             | No                           | No                        | Yes                                  |
+| Extension transactions            | No             | No                           | No                        | Yes                                  |
+| Hype Trains                       | History only   | No                           | No                        | Yes                                  |
+| Authorization grant/revoke        | No             | No                           | No                        | Yes                                  |
+| Drops                             | No             | No                           | No                        | No (supported by Twitch)             |
+| Additional concerns               | -              | -                            | -                         | As of now, must have a public server | 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "5.2.0-pre.2",
+	"version": "5.2.0-pre.3",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "5.2.0-pre.0",
+	"version": "5.2.0-pre.1",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "5.2.0-pre.1",
+	"version": "5.2.0-pre.2",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "5.1.6",
+	"version": "5.2.0-pre.0",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "5.2.0-pre.3",
+	"version": "5.2.0-pre.4",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "5.2.0-pre.4",
+	"version": "5.2.0-pre.5",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"command": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.0",
     "ts-jest": "^27.1.4",
-    "tsukuru": "^0.8.0-pre.4",
+    "tsukuru": "^0.8.0-pre.5",
     "typescript": "~4.6.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.0",
     "ts-jest": "^27.1.4",
-    "tsukuru": "^0.7.3",
+    "tsukuru": "^0.8.0-pre.3",
     "typescript": "~4.6.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "lint": "eslint --ext js,ts packages",
     "prettier:check": "prettier --check \"packages/**\"",
     "prettier:fix": "prettier --write \"packages/**\"",
-    "build": "lerna run build",
-    "rebuild": "lerna run rebuild",
+    "build": "tsukuru",
+    "rebuild": "tsukuru --clean",
     "docs": "documen.ts",
     "lerna": "lerna",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.0",
     "ts-jest": "^27.1.4",
-    "tsukuru": "^0.8.0-pre.3",
+    "tsukuru": "^0.8.0-pre.4",
     "typescript": "~4.6.3"
   },
   "scripts": {

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api-call",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
   "dependencies": {
     "@d-fischer/cross-fetch": "^4.0.2",
     "@d-fischer/qs": "^7.0.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.3",
     "@types/node-fetch": "^2.5.7",
     "tslib": "^2.0.3"
   },

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api-call",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
   "dependencies": {
     "@d-fischer/cross-fetch": "^4.0.2",
     "@d-fischer/qs": "^7.0.2",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.4",
     "@types/node-fetch": "^2.5.7",
     "tslib": "^2.0.3"
   },

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api-call",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
   "dependencies": {
     "@d-fischer/cross-fetch": "^4.0.2",
     "@d-fischer/qs": "^7.0.2",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.1",
     "@types/node-fetch": "^2.5.7",
     "tslib": "^2.0.3"
   },

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api-call",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
   "dependencies": {
     "@d-fischer/cross-fetch": "^4.0.2",
     "@d-fischer/qs": "^7.0.2",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.2",
     "@types/node-fetch": "^2.5.7",
     "tslib": "^2.0.3"
   },

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -42,9 +42,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api-call",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
   "dependencies": {
     "@d-fischer/cross-fetch": "^4.0.2",
     "@d-fischer/qs": "^7.0.2",
-    "@twurple/common": "^5.1.6",
+    "@twurple/common": "^5.2.0-pre.0",
     "@types/node-fetch": "^2.5.7",
     "tslib": "^2.0.3"
   },

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -41,6 +41,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api-call",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
   "dependencies": {
     "@d-fischer/cross-fetch": "^4.0.2",
     "@d-fischer/qs": "^7.0.2",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.5",
     "@types/node-fetch": "^2.5.7",
     "tslib": "^2.0.3"
   },

--- a/packages/api-call/tsconfig.json
+++ b/packages/api-call/tsconfig.json
@@ -1,8 +1,16 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -37,12 +37,12 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.4",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/api-call": "^5.2.0-pre.5",
+    "@twurple/common": "^5.2.0-pre.5",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4"
+    "@twurple/auth": "^5.2.0-pre.5"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -36,12 +36,12 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.1.6",
-    "@twurple/common": "^5.1.6",
+    "@twurple/api-call": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.1.6"
+    "@twurple/auth": "^5.2.0-pre.0"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -36,12 +36,12 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.0",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/api-call": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.1",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.0"
+    "@twurple/auth": "^5.2.0-pre.1"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -36,13 +36,13 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.3",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/api-call": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.4",
     "detect-node": "^2.1.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3",
+    "@twurple/auth": "^5.2.0-pre.4",
     "@types/detect-node": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,10 +38,12 @@
     "@d-fischer/shared-utils": "^3.2.0",
     "@twurple/api-call": "^5.2.0-pre.3",
     "@twurple/common": "^5.2.0-pre.3",
+    "detect-node": "^2.1.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3"
+    "@twurple/auth": "^5.2.0-pre.3",
+    "@types/detect-node": "^2.0.0"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -51,6 +51,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,17 +33,16 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/cache-decorators": "^3.0.0",
+    "@d-fischer/detect-node": "^3.0.1",
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@twurple/api-call": "^5.2.0-pre.4",
     "@twurple/common": "^5.2.0-pre.4",
-    "detect-node": "^2.1.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4",
-    "@types/detect-node": "^2.0.0"
+    "@twurple/auth": "^5.2.0-pre.4"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,9 +52,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -36,12 +36,12 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.1",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/api-call": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.2",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.1"
+    "@twurple/auth": "^5.2.0-pre.2"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/api",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -36,12 +36,12 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/api-call": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.2"
+    "@twurple/auth": "^5.2.0-pre.3"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/api/src/ApiClient.ts
+++ b/packages/api/src/ApiClient.ts
@@ -1,4 +1,5 @@
 import { Cacheable, CachedGetter } from '@d-fischer/cache-decorators';
+import { isNode } from '@d-fischer/detect-node';
 import type { Logger, LoggerOptions } from '@d-fischer/logger';
 import { createLogger } from '@d-fischer/logger';
 import type { RateLimiter } from '@d-fischer/rate-limiter';
@@ -15,7 +16,6 @@ import {
 import type { AuthProvider, TokenInfoData } from '@twurple/auth';
 import { accessTokenIsExpired, InvalidTokenError, TokenInfo } from '@twurple/auth';
 import { rtfm } from '@twurple/common';
-import * as isNode from 'detect-node';
 
 import { BadgesApi } from './api/badges/BadgesApi';
 import { HelixBitsApi } from './api/helix/bits/HelixBitsApi';

--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -932,6 +932,19 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribe to events that represent a user granting authorization to an application.
+	 *
+	 * @param clientId The Client ID for the application you want to listen to authorization grant events for.
+	 * @param transport The transport options.
+	 */
+	async subscribeToUserAuthorizationGrantEvents(
+		clientId: string,
+		transport: HelixEventSubTransportOptions
+	): Promise<HelixEventSubSubscription> {
+		return await this.createSubscription('user.authorization.grant', '1', { client_id: clientId }, transport);
+	}
+
+	/**
 	 * Subscribe to events that represent a user revoking their authorization from an application.
 	 *
 	 * @param clientId The Client ID for the application you want to listen to authorization revoke events for.

--- a/packages/api/src/api/helix/hypeTrain/HelixHypeTrainApi.ts
+++ b/packages/api/src/api/helix/hypeTrain/HelixHypeTrainApi.ts
@@ -71,24 +71,4 @@ export class HelixHypeTrainApi extends BaseApi {
 				new HelixHypeTrainEvent(data, this._client)
 		);
 	}
-
-	/**
-	 * Retrieves a single Hype Train event by ID.
-	 *
-	 * @param id The ID of the Hype Train event.
-	 */
-	async getHypeTrainEventById(id: string): Promise<HelixHypeTrainEvent | null> {
-		const result = await this._client.callApi<
-			HelixPaginatedResponse<HelixEventData<HelixHypeTrainEventData, HelixHypeTrainEventType>>
-		>({
-			type: 'helix',
-			url: 'hypetrain/events',
-			scope: 'channel:read:hype_train',
-			query: {
-				id
-			}
-		});
-
-		return result.data.length ? new HelixHypeTrainEvent(result.data[0], this._client) : null;
-	}
 }

--- a/packages/api/src/api/helix/moderation/HelixBanUser.ts
+++ b/packages/api/src/api/helix/moderation/HelixBanUser.ts
@@ -11,7 +11,7 @@ export interface HelixBanUserData {
 /**
  * Information about a user who has been banned/timed out.
  */
-@rtfm<HelixBanUser>('api', 'HelixBanUserRequest', 'userId')
+@rtfm<HelixBanUser>('api', 'HelixBanUser', 'userId')
 export class HelixBanUser extends DataObject<HelixBanUserData> {
 	/**
 	 * The ID of the broadcaster whose chat room the user was banned/timed out from chatting in.

--- a/packages/api/src/api/helix/moderation/HelixBanUser.ts
+++ b/packages/api/src/api/helix/moderation/HelixBanUser.ts
@@ -1,0 +1,43 @@
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+
+/** @private */
+export interface HelixBanUserData {
+	broadcaster_id: string;
+	end_time: string;
+	moderator_id: string;
+	user_id: string;
+}
+
+/**
+ * Information about a user who has been banned/timed out.
+ */
+@rtfm<HelixBanUser>('api', 'HelixBanUserRequest', 'userId')
+export class HelixBanUser extends DataObject<HelixBanUserData> {
+	/**
+	 * The ID of the broadcaster whose chat room the user was banned/timed out from chatting in.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_id;
+	}
+
+	/**
+	 * The UTC date and time (in RFC3339 format) that the timeout will end. Is null if the user was banned instead of put in a timeout.
+	 */
+	get endTime(): string {
+		return this[rawDataSymbol].end_time;
+	}
+
+	/**
+	 * The ID of the moderator that banned or put the user in the timeout.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].moderator_id;
+	}
+
+	/**
+	 * The ID of the user that was banned or was put in a timeout.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+}

--- a/packages/api/src/api/helix/moderation/HelixModerationApi.ts
+++ b/packages/api/src/api/helix/moderation/HelixModerationApi.ts
@@ -57,6 +57,9 @@ export interface HelixCheckAutoModStatusData {
 
 export type HelixAutoModSettingsUpdate = Exclude<HelixAutoModSettings, 'broadcasterId' | 'moderatorId'>;
 
+/**
+ * Information about a user to be banned/timed out from a channel.
+ */
 export interface HelixBanUserRequest {
 	/**
 	 * The duration (in seconds) that the user should be timed out. If this value is null, the user will be banned.
@@ -312,7 +315,10 @@ export class HelixModerationApi extends BaseApi {
 	 * @param broadcasterId The ID of the broadcaster in whose channel the user will be banned/timed out.
 	 * @param moderatorId The ID of a user that has permission to ban/timeout users in the broadcaster's chat room.
 	 * This must match the user ID associated with the user OAuth token.
-	 * @param data The data about the ban/timeout. Don't use the "data" wrapper.
+	 * @param data
+	 *
+	 * @expandParams
+	 *
 	 * @returns The result data from the ban/timeout request.
 	 */
 	async banUser(

--- a/packages/api/src/api/helix/moderation/HelixModerationApi.ts
+++ b/packages/api/src/api/helix/moderation/HelixModerationApi.ts
@@ -61,7 +61,7 @@ export interface HelixBanUserRequest {
 	/**
 	 * The duration (in seconds) that the user should be timed out. If this value is null, the user will be banned.
 	 */
-	duration: number | null;
+	duration?: number;
 
 	/**
 	 * The reason why the user is being timed out/banned.
@@ -312,8 +312,7 @@ export class HelixModerationApi extends BaseApi {
 	 * @param broadcasterId The ID of the broadcaster in whose channel the user will be banned/timed out.
 	 * @param moderatorId The ID of a user that has permission to ban/timeout users in the broadcaster's chat room.
 	 * This must match the user ID associated with the user OAuth token.
-	 * @param data The data about the ban/timeout, including the user's ID, the reason, and the duration (for timeouts only).
-	 * Don't use the "data" wrapper.
+	 * @param data The data about the ban/timeout. Don't use the "data" wrapper.
 	 * @returns The result data from the ban/timeout request.
 	 */
 	async banUser(

--- a/packages/api/src/api/helix/stream/HelixStreamApi.ts
+++ b/packages/api/src/api/helix/stream/HelixStreamApi.ts
@@ -129,14 +129,36 @@ export class HelixStreamApi extends BaseApi {
 	}
 
 	/**
-	 * Retrieves the current stream for the given user name.
+	 * Retrieves the current streams for the given usernames.
 	 *
-	 * @param user The user name to retrieve the stream for.
+	 * @param users The username to retrieve the streams for.
+	 */
+	async getStreamsByUserNames(users: UserNameResolvable[]): Promise<HelixStream[]> {
+		const result = await this.getStreams({ userName: users.map(extractUserName) });
+
+		return result.data;
+	}
+
+	/**
+	 * Retrieves the current stream for the given username.
+	 *
+	 * @param user The username to retrieve the stream for.
 	 */
 	async getStreamByUserName(user: UserNameResolvable): Promise<HelixStream | null> {
-		const result = await this.getStreams({ userName: extractUserName(user) });
+		const result = await this.getStreamsByUserNames([user]);
 
-		return result.data.length ? result.data[0] : null;
+		return result[0] ?? null;
+	}
+
+	/**
+	 * Retrieves the current streams for the given user IDs.
+	 *
+	 * @param users The user IDs to retrieve the streams for.
+	 */
+	async getStreamsByUserIds(users: UserIdResolvable[]): Promise<HelixStream[]> {
+		const result = await this.getStreams({ userId: users.map(extractUserId) });
+
+		return result.data;
 	}
 
 	/**
@@ -145,9 +167,9 @@ export class HelixStreamApi extends BaseApi {
 	 * @param user The user ID to retrieve the stream for.
 	 */
 	async getStreamByUserId(user: UserIdResolvable): Promise<HelixStream | null> {
-		const result = await this.getStreams({ userId: extractUserId(user) });
+		const result = await this.getStreamsByUserIds([user]);
 
-		return result.data.length ? result.data[0] : null;
+		return result[0] ?? null;
 	}
 
 	/**

--- a/packages/api/src/api/helix/stream/HelixStreamApi.ts
+++ b/packages/api/src/api/helix/stream/HelixStreamApi.ts
@@ -239,7 +239,7 @@ export class HelixStreamApi extends BaseApi {
 				method: 'POST',
 				type: 'helix',
 				scope: 'channel:manage:broadcast',
-				query: {
+				jsonBody: {
 					user_id: extractUserId(broadcaster),
 					description
 				}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -93,9 +93,14 @@ export { HelixHypeTrainEvent } from './api/helix/hypeTrain/HelixHypeTrainEvent';
 export type { HelixHypeTrainEventData, HelixHypeTrainEventType } from './api/helix/hypeTrain/HelixHypeTrainEvent';
 
 export { HelixModerationApi } from './api/helix/moderation/HelixModerationApi';
-export type { HelixBanFilter, HelixModeratorFilter } from './api/helix/moderation/HelixModerationApi';
+export type {
+	HelixBanFilter,
+	HelixModeratorFilter,
+	HelixBanUserRequest
+} from './api/helix/moderation/HelixModerationApi';
 export { HelixBan } from './api/helix/moderation/HelixBan';
 export { HelixModerator } from './api/helix/moderation/HelixModerator';
+export { HelixBanUser } from './api/helix/moderation/HelixBanUser';
 
 export { HelixPollApi } from './api/helix/poll/HelixPollApi';
 export type { HelixCreatePollData } from './api/helix/poll/HelixPollApi';

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,8 +1,24 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/api-call": ["../api-call/src"],
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../api-call"
+		},
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-electron",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3",
+    "@twurple/auth": "^5.2.0-pre.4",
     "electron": "^11.1.1"
   },
   "peerDependencies": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-electron",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.0",
+    "@twurple/auth": "^5.2.0-pre.1",
     "electron": "^11.1.1"
   },
   "peerDependencies": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -46,6 +46,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-electron",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4",
+    "@twurple/auth": "^5.2.0-pre.5",
     "electron": "^11.1.1"
   },
   "peerDependencies": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-electron",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.1.6",
+    "@twurple/auth": "^5.2.0-pre.0",
     "electron": "^11.1.1"
   },
   "peerDependencies": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-electron",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.1",
+    "@twurple/auth": "^5.2.0-pre.2",
     "electron": "^11.1.1"
   },
   "peerDependencies": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-electron",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.2",
+    "@twurple/auth": "^5.2.0-pre.3",
     "electron": "^11.1.1"
   },
   "peerDependencies": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -47,9 +47,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/auth-electron/tsconfig.json
+++ b/packages/auth-electron/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-ext",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.2",
+    "@twurple/auth": "^5.2.0-pre.3",
     "@types/twitch-ext": "^1.24.4"
   },
   "peerDependencies": {

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -45,9 +45,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-ext",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3",
+    "@twurple/auth": "^5.2.0-pre.4",
     "@types/twitch-ext": "^1.24.4"
   },
   "peerDependencies": {

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-ext",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.0",
+    "@twurple/auth": "^5.2.0-pre.1",
     "@types/twitch-ext": "^1.24.4"
   },
   "peerDependencies": {

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-ext",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.1",
+    "@twurple/auth": "^5.2.0-pre.2",
     "@types/twitch-ext": "^1.24.4"
   },
   "peerDependencies": {

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -44,6 +44,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-ext",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.1.6",
+    "@twurple/auth": "^5.2.0-pre.0",
     "@types/twitch-ext": "^1.24.4"
   },
   "peerDependencies": {

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-ext",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -32,7 +32,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4",
+    "@twurple/auth": "^5.2.0-pre.5",
     "@types/twitch-ext": "^1.24.4"
   },
   "peerDependencies": {

--- a/packages/auth-ext/tsconfig.json
+++ b/packages/auth-ext/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -53,9 +53,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-tmi",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.0",
+    "@twurple/auth": "^5.2.0-pre.1",
     "tmi.js": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -52,6 +52,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-tmi",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3",
+    "@twurple/auth": "^5.2.0-pre.4",
     "tmi.js": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-tmi",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.1.6",
+    "@twurple/auth": "^5.2.0-pre.0",
     "tmi.js": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-tmi",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.2",
+    "@twurple/auth": "^5.2.0-pre.3",
     "tmi.js": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-tmi",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.1",
+    "@twurple/auth": "^5.2.0-pre.2",
     "tmi.js": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth-tmi",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4",
+    "@twurple/auth": "^5.2.0-pre.5",
     "tmi.js": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/auth-tmi/tsconfig.json
+++ b/packages/auth-tmi/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -43,6 +43,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -44,9 +44,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,8 @@
   "dependencies": {
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/api-call": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.3",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,8 @@
   "dependencies": {
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.1.6",
-    "@twurple/common": "^5.1.6",
+    "@twurple/api-call": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.0",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,8 @@
   "dependencies": {
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.0",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/api-call": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.1",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,8 @@
   "dependencies": {
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.3",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/api-call": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.4",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,8 @@
   "dependencies": {
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.1",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/api-call": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.2",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/auth",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -34,8 +34,8 @@
   "dependencies": {
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.4",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/api-call": "^5.2.0-pre.5",
+    "@twurple/common": "^5.2.0-pre.5",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/api-call/src": ["../api-call/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../api-call"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/chat",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -38,12 +38,12 @@
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.5",
     "ircv3": "^0.29.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4"
+    "@twurple/auth": "^5.2.0-pre.5"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/chat",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -38,12 +38,12 @@
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.3",
     "ircv3": "^0.29.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.2"
+    "@twurple/auth": "^5.2.0-pre.3"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/chat",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -38,12 +38,12 @@
     "@d-fischer/rate-limiter": "^0.4.4",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.1.6",
+    "@twurple/common": "^5.2.0-pre.0",
     "ircv3": "^0.28.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.1.6"
+    "@twurple/auth": "^5.2.0-pre.0"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -35,11 +35,11 @@
     "@d-fischer/cache-decorators": "^3.0.0",
     "@d-fischer/deprecate": "^2.0.2",
     "@d-fischer/logger": "^4.0.0",
-    "@d-fischer/rate-limiter": "^0.4.4",
+    "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
     "@twurple/common": "^5.2.0-pre.1",
-    "ircv3": "^0.28.0",
+    "ircv3": "^0.29.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/chat",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -38,12 +38,12 @@
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.4",
     "ircv3": "^0.29.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3"
+    "@twurple/auth": "^5.2.0-pre.4"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/chat",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -38,12 +38,12 @@
     "@d-fischer/rate-limiter": "^0.5.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.2",
     "ircv3": "^0.29.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.1"
+    "@twurple/auth": "^5.2.0-pre.2"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -53,6 +53,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/chat",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -38,12 +38,12 @@
     "@d-fischer/rate-limiter": "^0.4.4",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.1",
     "ircv3": "^0.28.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.0"
+    "@twurple/auth": "^5.2.0-pre.1"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -54,9 +54,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/chat/src/ChatClient.ts
+++ b/packages/chat/src/ChatClient.ts
@@ -968,11 +968,10 @@ export class ChatClient extends IrcClient {
 					this.emit(event, channel, tags.get('login')!, subInfo, userNotice);
 					break;
 				}
-				case 'subgift':
-				case 'anonsubgift': {
+				case 'subgift': {
 					const plan = tags.get('msg-param-sub-plan')!;
 					const gifter = tags.get('login');
-					const isAnon = messageType === 'anonsubgift' || gifter === 'ananonymousgifter';
+					const isAnon = gifter === 'ananonymousgifter';
 					const subInfo: ChatSubGiftInfo = {
 						userId: tags.get('msg-param-recipient-id')!,
 						displayName: tags.get('msg-param-recipient-display-name')!,
@@ -989,10 +988,9 @@ export class ChatClient extends IrcClient {
 					this.emit(this.onSubGift, channel, tags.get('msg-param-recipient-user-name')!, subInfo, userNotice);
 					break;
 				}
-				case 'anonsubmysterygift':
 				case 'submysterygift': {
 					const gifter = tags.get('login');
-					const isAnon = messageType === 'anonsubmysterygift' || gifter === 'ananonymousgifter';
+					const isAnon = gifter === 'ananonymousgifter';
 					const communitySubInfo: ChatCommunitySubInfo = {
 						gifter: isAnon ? undefined : gifter,
 						gifterUserId: isAnon ? undefined : tags.get('user-id')!,

--- a/packages/chat/tsconfig.json
+++ b/packages/chat/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/common",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/common",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -38,6 +38,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/common",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -39,9 +39,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/common",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/common",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/common",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/src/errors/CustomError.ts
+++ b/packages/common/src/errors/CustomError.ts
@@ -10,15 +10,7 @@ export class CustomError extends Error {
 		super(message, options);
 
 		// restore prototype chain
-		const actualProto = new.target.prototype;
-
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		if (Object.setPrototypeOf) {
-			Object.setPrototypeOf(this, actualProto);
-		} else {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access
-			(this as any).__proto__ = actualProto;
-		}
+		Object.setPrototypeOf(this, new.target.prototype);
 
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		Error.captureStackTrace?.(this, new.target.constructor);

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "lib"

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/easy-bot",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/auth": "^5.1.6",
-    "@twurple/chat": "^5.1.6",
+    "@twurple/auth": "^5.2.0-pre.0",
+    "@twurple/chat": "^5.2.0-pre.0",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/easy-bot",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/auth": "^5.2.0-pre.0",
-    "@twurple/chat": "^5.2.0-pre.0",
+    "@twurple/auth": "^5.2.0-pre.1",
+    "@twurple/chat": "^5.2.0-pre.1",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/easy-bot",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/auth": "^5.2.0-pre.4",
-    "@twurple/chat": "^5.2.0-pre.4",
+    "@twurple/auth": "^5.2.0-pre.5",
+    "@twurple/chat": "^5.2.0-pre.5",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/easy-bot",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/auth": "^5.2.0-pre.1",
-    "@twurple/chat": "^5.2.0-pre.1",
+    "@twurple/auth": "^5.2.0-pre.2",
+    "@twurple/chat": "^5.2.0-pre.2",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -35,6 +35,9 @@
     "LICENSE",
     "README.md",
     "lib",
-    "!lib/**/*.d.ts.map"
+    "!lib/**/*.d.ts.map",
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/easy-bot",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/auth": "^5.2.0-pre.2",
-    "@twurple/chat": "^5.2.0-pre.2",
+    "@twurple/auth": "^5.2.0-pre.3",
+    "@twurple/chat": "^5.2.0-pre.3",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/easy-bot",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/auth": "^5.2.0-pre.3",
-    "@twurple/chat": "^5.2.0-pre.3",
+    "@twurple/auth": "^5.2.0-pre.4",
+    "@twurple/chat": "^5.2.0-pre.4",
     "tslib": "^2.0.3"
   },
   "files": [

--- a/packages/easy-bot/package.json
+++ b/packages/easy-bot/package.json
@@ -36,9 +36,5 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "rebuild": "rimraf lib && yarn run build"
-  }
+  ]
 }

--- a/packages/easy-bot/tsconfig.json
+++ b/packages/easy-bot/tsconfig.json
@@ -1,8 +1,24 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/chat": ["../chat/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../chat"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -45,10 +45,6 @@
     "!lib/**/*.d.ts.map",
     "es"
   ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.8"
   }

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -43,7 +43,9 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ],
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.8"

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/ebs-helper",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -33,8 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.4",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/api-call": "^5.2.0-pre.5",
+    "@twurple/common": "^5.2.0-pre.5",
     "jsonwebtoken": "^8.5.1",
     "tslib": "^2.0.3"
   },

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/ebs-helper",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -33,8 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.1.6",
-    "@twurple/common": "^5.1.6",
+    "@twurple/api-call": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.0",
     "jsonwebtoken": "^8.5.1",
     "tslib": "^2.0.3"
   },

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/ebs-helper",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -33,8 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.1",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/api-call": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.2",
     "jsonwebtoken": "^8.5.1",
     "tslib": "^2.0.3"
   },

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/ebs-helper",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -33,8 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.0",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/api-call": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.1",
     "jsonwebtoken": "^8.5.1",
     "tslib": "^2.0.3"
   },

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/ebs-helper",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -33,8 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/api-call": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.3",
     "jsonwebtoken": "^8.5.1",
     "tslib": "^2.0.3"
   },

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/ebs-helper",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -33,8 +33,8 @@
   "license": "MIT",
   "dependencies": {
     "@d-fischer/shared-utils": "^3.2.0",
-    "@twurple/api-call": "^5.2.0-pre.3",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/api-call": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.4",
     "jsonwebtoken": "^8.5.1",
     "tslib": "^2.0.3"
   },

--- a/packages/ebs-helper/tsconfig.json
+++ b/packages/ebs-helper/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/api-call": ["../api-call/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../api-call"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub-ngrok",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -38,8 +38,8 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.0",
-    "@twurple/eventsub": "^5.2.0-pre.0"
+    "@twurple/api": "^5.2.0-pre.1",
+    "@twurple/eventsub": "^5.2.0-pre.1"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0",

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub-ngrok",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -38,8 +38,8 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.3",
-    "@twurple/eventsub": "^5.2.0-pre.3"
+    "@twurple/api": "^5.2.0-pre.4",
+    "@twurple/eventsub": "^5.2.0-pre.4"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0",

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub-ngrok",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -38,8 +38,8 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.1.6",
-    "@twurple/eventsub": "^5.1.6"
+    "@twurple/api": "^5.2.0-pre.0",
+    "@twurple/eventsub": "^5.2.0-pre.0"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0",

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -51,9 +51,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub-ngrok",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -38,8 +38,8 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.4",
-    "@twurple/eventsub": "^5.2.0-pre.4"
+    "@twurple/api": "^5.2.0-pre.5",
+    "@twurple/eventsub": "^5.2.0-pre.5"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0",

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub-ngrok",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -38,8 +38,8 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.1",
-    "@twurple/eventsub": "^5.2.0-pre.1"
+    "@twurple/api": "^5.2.0-pre.2",
+    "@twurple/eventsub": "^5.2.0-pre.2"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0",

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -50,6 +50,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub-ngrok",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -38,8 +38,8 @@
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.2",
-    "@twurple/eventsub": "^5.2.0-pre.2"
+    "@twurple/api": "^5.2.0-pre.3",
+    "@twurple/eventsub": "^5.2.0-pre.3"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0",

--- a/packages/eventsub-ngrok/tsconfig.json
+++ b/packages/eventsub-ngrok/tsconfig.json
@@ -1,8 +1,28 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/api": ["../api/src"],
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"],
+			"@twurple/eventsub": ["../eventsub/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../api"
+		},
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		},
+		{
+			"path": "../eventsub"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -36,14 +36,14 @@
     "@d-fischer/raw-body": "^2.4.3",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/auth": "^5.1.6",
-    "@twurple/common": "^5.1.6",
+    "@twurple/auth": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.0",
     "@types/express-serve-static-core": "^4.17.24",
     "httpanda": "^0.4.6",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.1.6"
+    "@twurple/api": "^5.2.0-pre.0"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0"

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -36,14 +36,14 @@
     "@d-fischer/raw-body": "^2.4.3",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/auth": "^5.2.0-pre.1",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/auth": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.2",
     "@types/express-serve-static-core": "^4.17.24",
     "httpanda": "^0.4.6",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.1"
+    "@twurple/api": "^5.2.0-pre.2"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0"

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -36,14 +36,14 @@
     "@d-fischer/raw-body": "^2.4.3",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/auth": "^5.2.0-pre.3",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/auth": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.4",
     "@types/express-serve-static-core": "^4.17.24",
     "httpanda": "^0.4.6",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.3"
+    "@twurple/api": "^5.2.0-pre.4"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0"

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -36,14 +36,14 @@
     "@d-fischer/raw-body": "^2.4.3",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/auth": "^5.2.0-pre.0",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/auth": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.1",
     "@types/express-serve-static-core": "^4.17.24",
     "httpanda": "^0.4.6",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.0"
+    "@twurple/api": "^5.2.0-pre.1"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0"

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -36,14 +36,14 @@
     "@d-fischer/raw-body": "^2.4.3",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/auth": "^5.2.0-pre.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/auth": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.3",
     "@types/express-serve-static-core": "^4.17.24",
     "httpanda": "^0.4.6",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.2"
+    "@twurple/api": "^5.2.0-pre.3"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0"

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -53,6 +53,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/eventsub",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -36,14 +36,14 @@
     "@d-fischer/raw-body": "^2.4.3",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/auth": "^5.2.0-pre.4",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/auth": "^5.2.0-pre.5",
+    "@twurple/common": "^5.2.0-pre.5",
     "@types/express-serve-static-core": "^4.17.24",
     "httpanda": "^0.4.6",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/api": "^5.2.0-pre.4"
+    "@twurple/api": "^5.2.0-pre.5"
   },
   "peerDependencies": {
     "@twurple/api": "^5.0.0"

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -54,9 +54,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/eventsub/src/EventSubBase.ts
+++ b/packages/eventsub/src/EventSubBase.ts
@@ -43,6 +43,7 @@ import type { EventSubChannelUpdateEvent } from './events/EventSubChannelUpdateE
 import type { EventSubExtensionBitsTransactionCreateEvent } from './events/EventSubExtensionBitsTransactionCreateEvent';
 import type { EventSubStreamOfflineEvent } from './events/EventSubStreamOfflineEvent';
 import type { EventSubStreamOnlineEvent } from './events/EventSubStreamOnlineEvent';
+import type { EventSubUserAuthorizationGrantEvent } from './events/EventSubUserAuthorizationGrantEvent';
 import type { EventSubUserAuthorizationRevokeEvent } from './events/EventSubUserAuthorizationRevokeEvent';
 import type { EventSubUserUpdateEvent } from './events/EventSubUserUpdateEvent';
 import { EventSubChannelBanSubscription } from './subscriptions/EventSubChannelBanSubscription';
@@ -79,6 +80,7 @@ import { EventSubExtensionBitsTransactionCreateSubscription } from './subscripti
 import { EventSubStreamOfflineSubscription } from './subscriptions/EventSubStreamOfflineSubscription';
 import { EventSubStreamOnlineSubscription } from './subscriptions/EventSubStreamOnlineSubscription';
 import type { EventSubSubscription } from './subscriptions/EventSubSubscription';
+import { EventSubUserAuthorizationGrantSubscription } from './subscriptions/EventSubUserAuthorizationGrantSubscription';
 import { EventSubUserAuthorizationRevokeSubscription } from './subscriptions/EventSubUserAuthorizationRevokeSubscription';
 import { EventSubUserUpdateSubscription } from './subscriptions/EventSubUserUpdateSubscription';
 
@@ -984,6 +986,19 @@ To silence this warning without enabling this check (and thus to keep it off eve
 	}
 
 	/**
+	 * Subscribes to events that represent a user granting authorization to an application.
+	 *
+	 * @param clientId The Client ID for which to get notifications about authorization grants.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	async subscribeToUserAuthorizationGrantEvents(
+		clientId: string,
+		handler: (data: EventSubUserAuthorizationGrantEvent) => void
+	): Promise<EventSubSubscription> {
+		return await this._genericSubscribe(EventSubUserAuthorizationGrantSubscription, handler, this, clientId);
+	}
+
+	/**
 	 * Subscribes to events that represent a user revoking authorization from an application.
 	 *
 	 * @param clientId The Client ID for which to get notifications about authorization revocations.
@@ -995,6 +1010,7 @@ To silence this warning without enabling this check (and thus to keep it off eve
 	): Promise<EventSubSubscription> {
 		return await this._genericSubscribe(EventSubUserAuthorizationRevokeSubscription, handler, this, clientId);
 	}
+
 	/**
 	 * Subscribes to events that represent a user updating their account details.
 	 *

--- a/packages/eventsub/src/events/EventSubUserAuthorizationGrantEvent.ts
+++ b/packages/eventsub/src/events/EventSubUserAuthorizationGrantEvent.ts
@@ -1,0 +1,59 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+
+/** @private */
+export interface EventSubUserAuthorizationGrantEventData {
+	client_id: string;
+	user_id: string;
+	user_login: string;
+	user_name: string;
+}
+/**
+ * An EventSub event representing a user revoking authorization for an application.
+ */
+@rtfm<EventSubUserAuthorizationGrantEvent>('eventsub', 'EventSubUserAuthorizationGrantEvent', 'userId')
+export class EventSubUserAuthorizationGrantEvent extends DataObject<EventSubUserAuthorizationGrantEventData> {
+	@Enumerable(false) private readonly _client: ApiClient;
+
+	/** @private */
+	constructor(data: EventSubUserAuthorizationGrantEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the user who granted the authorization.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the user who granted the authorization.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the user who granted the authorization.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Retrieves more information about the user.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return (await this._client.users.getUserById(this[rawDataSymbol].user_id))!;
+	}
+
+	/**
+	 * The Client ID of the application that the user granted authorization to.
+	 */
+	get clientId(): string {
+		return this[rawDataSymbol].client_id;
+	}
+}

--- a/packages/eventsub/src/subscriptions/EventSubUserAuthorizationGrantSubscription.ts
+++ b/packages/eventsub/src/subscriptions/EventSubUserAuthorizationGrantSubscription.ts
@@ -1,0 +1,37 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubUserAuthorizationGrantEventData } from '../events/EventSubUserAuthorizationGrantEvent';
+import { EventSubUserAuthorizationGrantEvent } from '../events/EventSubUserAuthorizationGrantEvent';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+
+/**
+ * @private
+ */
+@rtfm('eventsub', 'EventSubSubscription')
+export class EventSubUserAuthorizationGrantSubscription extends EventSubSubscription<EventSubUserAuthorizationGrantEvent> {
+	protected readonly _cliName = 'grant';
+
+	constructor(
+		handler: (data: EventSubUserAuthorizationGrantEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `user.authorization.grant.${this._userId}`;
+	}
+
+	protected transformData(data: EventSubUserAuthorizationGrantEventData): EventSubUserAuthorizationGrantEvent {
+		return new EventSubUserAuthorizationGrantEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToUserAuthorizationGrantEvents(
+			this._userId,
+			await this._getTransportOptions()
+		);
+	}
+}

--- a/packages/eventsub/tsconfig.json
+++ b/packages/eventsub/tsconfig.json
@@ -1,8 +1,24 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/api": ["../api/src"],
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../api"
+		},
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/pubsub",
-  "version": "5.2.0-pre.3",
+  "version": "5.2.0-pre.4",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.3",
+    "@twurple/common": "^5.2.0-pre.4",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.3"
+    "@twurple/auth": "^5.2.0-pre.4"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/pubsub",
-  "version": "5.2.0-pre.0",
+  "version": "5.2.0-pre.1",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.0",
+    "@twurple/common": "^5.2.0-pre.1",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.0"
+    "@twurple/auth": "^5.2.0-pre.1"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/pubsub",
-  "version": "5.1.6",
+  "version": "5.2.0-pre.0",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.1.6",
+    "@twurple/common": "^5.2.0-pre.0",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.1.6"
+    "@twurple/auth": "^5.2.0-pre.0"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -48,6 +48,8 @@
     "README.md",
     "lib",
     "!lib/**/*.d.ts.map",
-    "es"
+    "es",
+    "!es/**/*.d.ts",
+    "!es/**/*.d.ts.map"
   ]
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -49,9 +49,5 @@
     "lib",
     "!lib/**/*.d.ts.map",
     "es"
-  ],
-  "scripts": {
-    "build": "tsukuru",
-    "rebuild": "tsukuru --clean"
-  }
+  ]
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/pubsub",
-  "version": "5.2.0-pre.2",
+  "version": "5.2.0-pre.3",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.2",
+    "@twurple/common": "^5.2.0-pre.3",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.2"
+    "@twurple/auth": "^5.2.0-pre.3"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/pubsub",
-  "version": "5.2.0-pre.4",
+  "version": "5.2.0-pre.5",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.4",
+    "@twurple/common": "^5.2.0-pre.5",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.4"
+    "@twurple/auth": "^5.2.0-pre.5"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twurple/pubsub",
-  "version": "5.2.0-pre.1",
+  "version": "5.2.0-pre.2",
   "publishConfig": {
     "access": "public"
   },
@@ -34,11 +34,11 @@
     "@d-fischer/logger": "^4.0.0",
     "@d-fischer/shared-utils": "^3.2.0",
     "@d-fischer/typed-event-emitter": "^3.2.2",
-    "@twurple/common": "^5.2.0-pre.1",
+    "@twurple/common": "^5.2.0-pre.2",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
-    "@twurple/auth": "^5.2.0-pre.1"
+    "@twurple/auth": "^5.2.0-pre.2"
   },
   "peerDependencies": {
     "@twurple/auth": "^5.0.0"

--- a/packages/pubsub/tsconfig.json
+++ b/packages/pubsub/tsconfig.json
@@ -1,8 +1,20 @@
 {
-	"extends": "../../tsconfig",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "lib"
+		"outDir": "lib",
+		"paths": {
+			"@twurple/auth": ["../auth/src"],
+			"@twurple/common": ["../common/src"]
+		}
 	},
+	"references": [
+		{
+			"path": "../auth"
+		},
+		{
+			"path": "../common"
+		}
+	],
 	"exclude": ["node_modules", "lib", "es"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"composite": true,
+		"module": "commonjs",
+		"target": "es2019",
+		"lib": ["es2019"],
+		"moduleResolution": "node",
+		"declaration": true,
+		"forceConsistentCasingInFileNames": true,
+		"noImplicitReturns": true,
+		"importHelpers": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"experimentalDecorators": true,
+		"downlevelIteration": true,
+		"isolatedModules": true,
+		"declarationMap": true
+	},
+	"exclude": ["node_modules", "lib", "es"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
 		"composite": true,
 		"module": "commonjs",
 		"target": "es2019",
-		"lib": ["es2019"],
+		"lib": ["es2019", "es2021.promise", "es2022.error"],
 		"moduleResolution": "node",
 		"declaration": true,
 		"forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,44 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "es2019",
-		"lib": ["es2019", "es2021.promise", "es2022.error"],
-		"moduleResolution": "node",
-		"declaration": true,
-		"forceConsistentCasingInFileNames": true,
-		"noImplicitReturns": true,
-		"importHelpers": true,
-		"strict": true,
-		"noUnusedLocals": true,
-		"experimentalDecorators": true,
-		"downlevelIteration": true,
-		"isolatedModules": true,
-		"declarationMap": true
-	},
-	"exclude": ["node_modules", "lib", "es", "__tests__"]
+	"references": [
+		{
+			"path": "./packages/api"
+		},
+		{
+			"path": "./packages/api-call"
+		},
+		{
+			"path": "./packages/auth"
+		},
+		{
+			"path": "./packages/auth-electron"
+		},
+		{
+			"path": "./packages/auth-ext"
+		},
+		{
+			"path": "./packages/auth-tmi"
+		},
+		{
+			"path": "./packages/chat"
+		},
+		{
+			"path": "./packages/common"
+		},
+		{
+			"path": "./packages/easy-bot"
+		},
+		{
+			"path": "./packages/ebs-helper"
+		},
+		{
+			"path": "./packages/eventsub"
+		},
+		{
+			"path": "./packages/eventsub-ngrok"
+		},
+		{
+			"path": "./packages/pubsub"
+		}
+	],
+	"files": []
 }


### PR DESCRIPTION
Type: Bugfix

Fixes: https://discord.com/channels/325552783787032576/350012219003764748/995436568007430164

`user_id` and `description` are meant to be body params (rather than query params): https://dev.twitch.tv/docs/api/reference#create-stream-marker