### PR TITLE
fix(api): pass create stream marker params to body

### DIFF
--- a/packages/api/src/api/helix/stream/HelixStreamApi.ts
+++ b/packages/api/src/api/helix/stream/HelixStreamApi.ts
@@ -217,7 +217,7 @@ export class HelixStreamApi extends BaseApi {
 				method: 'POST',
 				type: 'helix',
 				scope: 'channel:manage:broadcast',
-				query: {
+				jsonBody: {
 					user_id: extractUserId(broadcaster),
 					description
 				}


### PR DESCRIPTION
Type: Bugfix

Fixes: https://discord.com/channels/325552783787032576/350012219003764748/995436568007430164

`user_id` and `description` are meant to be body params (rather than query params): https://dev.twitch.tv/docs/api/reference#create-stream-marker

Supersedes #365 (rebased incorrectly & am lazy)
