### PR TITLE
Send Chat Announcement via Helix

### DIFF
--- a/docs/getting-data/index.md
+++ b/docs/getting-data/index.md
@@ -41,7 +41,7 @@ should use for which use case.
 | Host users                                    | No                       | Yes                            |
 | Raid users                                    | Yes                      | Yes                            |
 | Send chat messages                            | No                       | Yes                            |
-| Send chat announcements                       | No                       | Yes                            |
+| Send chat announcements                       | Yes                      | Yes                            |
 | Remove chat messages                          | No                       | Yes                            |
 | Set chat modes (e.g. emote/sub/follower only) | Yes                      | Yes                            |
 | Get & manage AutoMod settings                 | Yes                      | No                             |

--- a/packages/api/src/api/helix/chat/HelixChatApi.ts
+++ b/packages/api/src/api/helix/chat/HelixChatApi.ts
@@ -66,6 +66,26 @@ export interface HelixUpdateChatSettingsParams {
 }
 
 /**
+ * The color used to highlight an announcement.
+ */
+export type HelixChatAnnoucementColor = 'blue' | 'green' | 'orange' | 'purple' | 'primary';
+
+/**
+ * A request to send an announcement to a broadcaster's chat.
+ */
+export interface HelixSendChatAnnoucementParams {
+	/**
+	 * The annoucement to make in the broadcaster's chat room. Announcements are limited to a maximum of 500 characters; announcements longer than 500 characters are truncated.
+	 */
+	message: string;
+
+	/**
+	 * The color used to highlight the announcement. If color is set to `primary` or is not set, the channel’s accent color is used to highlight the announcement.
+	 */
+	color?: HelixChatAnnoucementColor;
+}
+
+/**
  * The Helix API methods that deal with chat.
  *
  * Can be accessed using `client.chat` on an {@ApiClient} instance.
@@ -236,5 +256,36 @@ export class HelixChatApi extends BaseApi {
 		});
 
 		return new HelixPrivilegedChatSettings(result.data[0]);
+	}
+
+	/**
+	 * Sends an announcement to a broadcaster's chat.
+	 *
+	 * @param broadcaster The broadcaster the chat belongs to.
+	 * @param moderator The moderator the request is on behalf of.
+	 *
+	 * This is the user your user token needs to represent.
+	 * You can get your own settings by setting `broadcaster` and `moderator` to the same user.
+	 * @param announcement The announcement to send.
+	 */
+	async sendChatAnnouncement(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		announcement: HelixSendChatAnnoucementParams
+	): Promise<void> {
+		await this._client.callApi<unknown>({
+			type: 'helix',
+			url: 'chat/announcements',
+			method: 'POST',
+			scope: 'moderator:manage:announcements',
+			query: {
+				broadcaster_id: extractUserId(broadcaster),
+				moderator_id: extractUserId(moderator)
+			},
+			jsonBody: {
+				message: announcement.message,
+				color: announcement.color
+			}
+		});
 	}
 }

--- a/packages/api/src/api/helix/chat/HelixChatApi.ts
+++ b/packages/api/src/api/helix/chat/HelixChatApi.ts
@@ -273,7 +273,7 @@ export class HelixChatApi extends BaseApi {
 		moderator: UserIdResolvable,
 		announcement: HelixSendChatAnnoucementParams
 	): Promise<void> {
-		await this._client.callApi<unknown>({
+		await this._client.callApi({
 			type: 'helix',
 			url: 'chat/announcements',
 			method: 'POST',

--- a/packages/api/src/api/helix/chat/HelixChatApi.ts
+++ b/packages/api/src/api/helix/chat/HelixChatApi.ts
@@ -265,7 +265,7 @@ export class HelixChatApi extends BaseApi {
 	 * @param moderator The moderator the request is on behalf of.
 	 *
 	 * This is the user your user token needs to represent.
-	 * You can get your own settings by setting `broadcaster` and `moderator` to the same user.
+	 * You can send an announcement to your own chat by setting `broadcaster` and `moderator` to the same user.
 	 * @param announcement The announcement to send.
 	 */
 	async sendChatAnnouncement(

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -43,7 +43,11 @@ export type {
 } from './api/helix/channelPoints/HelixCustomRewardRedemption';
 
 export { HelixChatApi } from './api/helix/chat/HelixChatApi';
-export type { HelixUpdateChatSettingsParams } from './api/helix/chat/HelixChatApi';
+export type {
+	HelixUpdateChatSettingsParams,
+	HelixSendChatAnnoucementParams,
+	HelixChatAnnoucementColor
+} from './api/helix/chat/HelixChatApi';
 export { HelixChatBadgeSet } from './api/helix/chat/HelixChatBadgeSet';
 export { HelixChatBadgeVersion } from './api/helix/chat/HelixChatBadgeVersion';
 export type { HelixChatBadgeScale } from './api/helix/chat/HelixChatBadgeVersion';


### PR DESCRIPTION
Type: Feature

Fixes: #369 

Adds support for the new Send Chat Announcement endpoint in the Helix API.