### PR TITLE
Fix: Missing TypeScript Definitions with ECMAScript Modules 

### DIFF
--- a/packages/api-call/package.json
+++ b/packages/api-call/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/auth-electron/package.json
+++ b/packages/auth-electron/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/auth-ext/package.json
+++ b/packages/auth-ext/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/auth-tmi/package.json
+++ b/packages/auth-tmi/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/ebs-helper/package.json
+++ b/packages/ebs-helper/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/eventsub/package.json
+++ b/packages/eventsub/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
Type: Bugfix
Fixes: #383

**Description:**

Add `"types": "./lib/index.d.ts"` for each library with separate ES module paths. This allows TypeScript to detect the type declaration files when importing into ES module projects.

**Tests**
- [x] Linked package locally, tested on example from #383; Fails without change, succeeds with change