### PR TITLE
 Fix: Missing TypeScript Definitions with ECMAScript Modules (api, eventsub-ngrok)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {

--- a/packages/eventsub-ngrok/package.json
+++ b/packages/eventsub-ngrok/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
Type: Bugfix
Fixes: https://github.com/twurple/twurple/issues/383

Description:

Add "types": "./lib/index.d.ts" for each library with separate ES module paths. This allows TypeScript to detect the type declaration files when importing into ES module projects.

Added missing definitions from #384 for @twurple/api and @twurple/eventsub-ngrok