### PR TITLE
set `indent_size = 4` for all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,11 +5,8 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = tab
-max_line_length = 120
-
-[*.json]
-indent_style = tab
 indent_size = 4
+max_line_length = 120
 
 [package.json]
 indent_style = space


### PR DESCRIPTION
By default on github tab width is 8 spaces. 
That makes harder to read the source code.
So I suggest to set `indent_size = 4` for all files instead of only for `*.json` files.