### PR TITLE
Property 'mutedSegmentData' must allow null

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,11 +5,8 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = tab
-max_line_length = 120
-
-[*.json]
-indent_style = tab
 indent_size = 4
+max_line_length = 120
 
 [package.json]
 indent_style = space

--- a/packages/api/src/api/helix/video/HelixVideo.ts
+++ b/packages/api/src/api/helix/video/HelixVideo.ts
@@ -40,7 +40,7 @@ export interface HelixVideoData {
 	type: HelixVideoType;
 	duration: string;
 	stream_id: string | null;
-	muted_segments: HelixVideoMutedSegmentData[];
+	muted_segments: HelixVideoMutedSegmentData[] | null;
 }
 
 /**
@@ -216,7 +216,7 @@ export class HelixVideo extends DataObject<HelixVideoData> {
 	 * The raw data of muted segments of the video.
 	 */
 	get mutedSegmentData(): HelixVideoMutedSegmentData[] {
-		return this[rawDataSymbol].muted_segments.slice();
+		return this[rawDataSymbol].muted_segments?.slice() ?? [];
 	}
 
 	/**
@@ -230,8 +230,12 @@ export class HelixVideo extends DataObject<HelixVideoData> {
 	 * By default, this function returns true only if the passed range is entirely contained in a muted segment.
 	 */
 	isMutedAt(offset: number, duration?: number, partial = false): boolean {
+		if (this[rawDataSymbol].muted_segments === null) {
+			return false;
+		}
+
 		if (duration == null) {
-			return this[rawDataSymbol].muted_segments.some(
+			return this[rawDataSymbol].muted_segments!.some(
 				seg => seg.offset <= offset && offset <= seg.offset + seg.duration
 			);
 		}
@@ -239,14 +243,14 @@ export class HelixVideo extends DataObject<HelixVideoData> {
 		const end = offset + duration;
 
 		if (partial) {
-			return this[rawDataSymbol].muted_segments.some(seg => {
+			return this[rawDataSymbol].muted_segments!.some(seg => {
 				const segEnd = seg.offset + seg.duration;
 
 				return offset < segEnd && seg.offset < end;
 			});
 		}
 
-		return this[rawDataSymbol].muted_segments.some(seg => {
+		return this[rawDataSymbol].muted_segments!.some(seg => {
 			const segEnd = seg.offset + seg.duration;
 
 			return seg.offset <= offset && end <= segEnd;

--- a/packages/eventsub/src/adapters/DirectConnectionAdapter.ts
+++ b/packages/eventsub/src/adapters/DirectConnectionAdapter.ts
@@ -31,7 +31,8 @@ export interface DirectConnectionAdapterConfig {
 @rtfm('eventsub', 'DirectConnectionAdapter')
 export class DirectConnectionAdapter extends ConnectionAdapter {
 	private readonly _hostName: string;
-	@Enumerable(false) private readonly _ssl: EventSubListenerCertificateConfig;
+	@Enumerable(false) private _ssl: EventSubListenerCertificateConfig;
+	@Enumerable(false) private _httpsServer?: https.Server;
 
 	/**
 	 * Creates a new simple WebHook adapter.
@@ -49,12 +50,24 @@ export class DirectConnectionAdapter extends ConnectionAdapter {
 		this._ssl = options.sslCert;
 	}
 
+	/**
+	 * Updates the SSL certificate, for example if the old one is expired.
+	 *
+	 * @expandParams
+	 *
+	 * @param ssl The new certificate data.
+	 */
+	updateSslCertificate(ssl: EventSubListenerCertificateConfig): void {
+		this._ssl = ssl;
+		this._httpsServer?.setSecureContext(ssl);
+	}
+
 	/** @protected */
 	createHttpServer(): http.Server {
-		return https.createServer({
+		return (this._httpsServer = https.createServer({
 			key: this._ssl.key,
 			cert: this._ssl.cert
-		});
+		}));
 	}
 
 	/** @protected */


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type:  #Bugfix

<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #388 

<!-- Here you can explain in further detail what your pull request contains. -->

`mutedSegmentData`
Array of muted segments in the video.
If there are no muted segments, the value will be `null`.
[twitch reference](https://dev.twitch.tv/docs/api/reference#get-videos)

my solution 
```ts
muted_segments: HelixVideoMutedSegmentData[];  // -> muted_segments: HelixVideoMutedSegmentData[] | null; 
```

