### PR TITLE
Expose winningOutcomeId and winningOutcome on the HelixPrediction object

### DIFF
--- a/packages/api/src/api/helix/prediction/HelixPrediction.ts
+++ b/packages/api/src/api/helix/prediction/HelixPrediction.ts
@@ -1,5 +1,5 @@
 import { Enumerable } from '@d-fischer/shared-utils';
-import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { DataObject, HellFreezesOverError, rawDataSymbol, rtfm } from '@twurple/common';
 import type { ApiClient } from '../../../ApiClient';
 import type { HelixUser } from '../user/HelixUser';
 import type { HelixPredictionOutcomeData } from './HelixPredictionOutcome';
@@ -121,5 +121,27 @@ export class HelixPrediction extends DataObject<HelixPredictionData> {
 	 */
 	get outcomes(): HelixPredictionOutcome[] {
 		return this[rawDataSymbol].outcomes.map(data => new HelixPredictionOutcome(data, this._client));
+	}
+
+	/**
+	 * The ID of the winning outcome, or null if the prediction was canceled.
+	 */
+	get winningOutcomeId(): string | null {
+		return this[rawDataSymbol].winning_outcome_id;
+	}
+
+	/**
+	 * The winning outcome, or null if the prediction was canceled.
+	 */
+	get winningOutcome(): HelixPredictionOutcome | null {
+		if (this[rawDataSymbol].winning_outcome_id === null) {
+			return null;
+		}
+
+		const found = this[rawDataSymbol].outcomes.find(o => o.id === this[rawDataSymbol].winning_outcome_id);
+		if (!found) {
+			throw new HellFreezesOverError('Winning outcome not found in outcomes array');
+		}
+		return new HelixPredictionOutcome(found, this._client);
 	}
 }

--- a/packages/api/src/api/helix/prediction/HelixPrediction.ts
+++ b/packages/api/src/api/helix/prediction/HelixPrediction.ts
@@ -124,14 +124,14 @@ export class HelixPrediction extends DataObject<HelixPredictionData> {
 	}
 
 	/**
-	 * The ID of the winning outcome, or null if the prediction was canceled.
+	 * The ID of the winning outcome, or null if the prediction is currently running or was canceled.
 	 */
 	get winningOutcomeId(): string | null {
 		return this[rawDataSymbol].winning_outcome_id;
 	}
 
 	/**
-	 * The winning outcome, or null if the prediction was canceled.
+	 * The winning outcome, or null if the prediction is currently running or was canceled.
 	 */
 	get winningOutcome(): HelixPredictionOutcome | null {
 		if (this[rawDataSymbol].winning_outcome_id === null) {


### PR DESCRIPTION
Type: Bugfix
Fixes: #398

It appears that winningOutcomeId wasn't included on the HelixPrediction object, even though it was being fetched.

Here I just copied over the equivalent code from `packages/eventsub/src/events/EventSubChannelPredictionEndEvent.ts`.

Since it's such a tiny thing I went ahead and wrote a quick commit even though I don't think anyone has seen it yet.