### PR TITLE
Change clip fetch documentation to indicate clips are returned by view count, not creation date

### DIFF
--- a/packages/api/src/api/helix/clip/HelixClipApi.ts
+++ b/packages/api/src/api/helix/clip/HelixClipApi.ts
@@ -82,7 +82,7 @@ export interface HelixClipCreateResponse {
 @rtfm('api', 'HelixClipApi')
 export class HelixClipApi extends BaseApi {
 	/**
-	 * Retrieves the latest clips for the specified broadcaster.
+	 * Retrieves clips for the specified broadcaster in descending order of views.
 	 *
 	 * @param user The broadcaster to fetch clips for.
 	 * @param filter
@@ -101,7 +101,7 @@ export class HelixClipApi extends BaseApi {
 	}
 
 	/**
-	 * Creates a paginator for the latest clips for the specified broadcaster.
+	 * Creates a paginator for clips for the specified broadcaster.
 	 *
 	 * @param user The broadcaster to fetch clips for.
 	 * @param filter
@@ -120,7 +120,7 @@ export class HelixClipApi extends BaseApi {
 	}
 
 	/**
-	 * Retrieves the latest clips for the specified game.
+	 * Retrieves clips for the specified game in descending order of views.
 	 *
 	 * @param gameId The game ID.
 	 * @param filter
@@ -139,7 +139,7 @@ export class HelixClipApi extends BaseApi {
 	}
 
 	/**
-	 * Creates a paginator for the latest clips for the specified game.
+	 * Creates a paginator for clips for the specified game.
 	 *
 	 * @param gameId The game ID.
 	 * @param filter


### PR DESCRIPTION
Type: bugfix

As [reported on Discord](https://discord.com/channels/325552783787032576/350012219003764748/1032633418590208010), a small documentation tweak to indicate that clips are returned in descending order of views, rather than by creation date. Since it's a small change I didn't open an issue but if you would prefer I do so in the future I will.

See the Twitch documentation for [getting a broadcaster's clips](https://dev.twitch.tv/docs/api/clips#getting-a-broadcasters-clips) and [getting a game's clips](https://dev.twitch.tv/docs/api/clips#getting-a-games-clips).