### PR TITLE
fix: EventSub WS reconnect message_type

### DIFF
--- a/packages/eventsub-ws/src/EventSubWsListener.ts
+++ b/packages/eventsub-ws/src/EventSubWsListener.ts
@@ -149,7 +149,7 @@ export class EventSubWsListener extends EventSubBase implements EventSubListener
 					subscription._handleData((payload as EventSubNotificationPayload).event);
 					break;
 				}
-				case 'reconnect': {
+				case 'session_reconnect': {
 					await this._connection?.disconnect();
 					await this._connectTo((payload as EventSubReconnectPayload).session.reconnect_url!);
 					break;


### PR DESCRIPTION
Type: Bugfix

Fixes: #416

Resolves the issue with listening for the wrong `message_type` for EventSub Websocket reconnect messages. Now listens for `session_reconnect` instead of `reconnect`, per Twitch docs.

https://dev.twitch.tv/docs/eventsub/handling-websocket-events#reconnect-message