### PR TITLE
Add missing HelixEmote fields

### DIFF
--- a/packages/api/src/api/helix/chat/HelixEmote.ts
+++ b/packages/api/src/api/helix/chat/HelixEmote.ts
@@ -57,26 +57,28 @@ export class HelixEmote extends DataObject<HelixEmoteData> {
 	}
 
 	/**
-	 * Gets the URL of the emote image in static format at the given scale, or null if a static emote image at that scale doesn't exist.
+	 * Gets the URL of the emote image in static format at the given scale and theme mode, or null if a static emote image at that scale/theme mode doesn't exist.
 	 *
 	 * @param scale The scale of the image.
+	 * @param themeMode The theme mode of the image, either `light` or `dark`.
 	 */
-	getStaticImageUrl(scale: HelixEmoteScale = '1.0'): string | null {
+	getStaticImageUrl(scale: HelixEmoteScale = '1.0', themeMode: HelixEmoteThemeMode = 'light'): string | null {
 		if (this[rawDataSymbol].format.includes('static') && this[rawDataSymbol].scale.includes(scale)) {
-			this.getFormattedImageUrl(scale, 'static');
+			this.getFormattedImageUrl(scale, 'static', themeMode);
 		}
 
 		return null;
 	}
 
 	/**
-	 * Gets the URL of the emote image in animated format at the given scale, or null if an animated emote image at that scale doesn't exist.
+	 * Gets the URL of the emote image in animated format at the given scale and theme mode, or null if an animated emote image at that scale/theme mode doesn't exist.
 	 *
 	 * @param scale The scale of the image.
+	 * @param themeMode The theme mode of the image, either `light` or `dark`.
 	 */
-	getAnimatedImageUrl(scale: HelixEmoteScale = '1.0'): string | null {
+	getAnimatedImageUrl(scale: HelixEmoteScale = '1.0', themeMode: HelixEmoteThemeMode = 'light'): string | null {
 		if (this[rawDataSymbol].format.includes('animated') && this[rawDataSymbol].scale.includes(scale)) {
-			this.getFormattedImageUrl(scale, 'animated');
+			this.getFormattedImageUrl(scale, 'animated', themeMode);
 		}
 
 		return null;

--- a/packages/api/src/api/helix/chat/HelixEmote.ts
+++ b/packages/api/src/api/helix/chat/HelixEmote.ts
@@ -64,7 +64,7 @@ export class HelixEmote extends DataObject<HelixEmoteData> {
 	 */
 	getStaticImageUrl(scale: HelixEmoteScale = '1.0', themeMode: HelixEmoteThemeMode = 'light'): string | null {
 		if (this[rawDataSymbol].format.includes('static') && this[rawDataSymbol].scale.includes(scale)) {
-			this.getFormattedImageUrl(scale, 'static', themeMode);
+			return this.getFormattedImageUrl(scale, 'static', themeMode);
 		}
 
 		return null;
@@ -78,7 +78,7 @@ export class HelixEmote extends DataObject<HelixEmoteData> {
 	 */
 	getAnimatedImageUrl(scale: HelixEmoteScale = '1.0', themeMode: HelixEmoteThemeMode = 'light'): string | null {
 		if (this[rawDataSymbol].format.includes('animated') && this[rawDataSymbol].scale.includes(scale)) {
-			this.getFormattedImageUrl(scale, 'animated', themeMode);
+			return this.getFormattedImageUrl(scale, 'animated', themeMode);
 		}
 
 		return null;

--- a/packages/api/src/api/helix/chat/HelixEmote.ts
+++ b/packages/api/src/api/helix/chat/HelixEmote.ts
@@ -1,5 +1,11 @@
 import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
-import { type HelixEmoteData, type HelixEmoteImageScale } from '../../../interfaces/helix/chat.external';
+import {
+	type HelixEmoteFormat,
+	type HelixEmoteScale,
+	type HelixEmoteThemeMode,
+	type HelixEmoteData,
+	type HelixEmoteImageScale
+} from '../../../interfaces/helix/chat.external';
 
 /**
  * A Twitch emote.
@@ -21,11 +27,73 @@ export class HelixEmote extends DataObject<HelixEmoteData> {
 	}
 
 	/**
+	 * The formats that the emote is available in.
+	 */
+	get formats(): HelixEmoteFormat[] {
+		return this[rawDataSymbol].format;
+	}
+
+	/**
+	 * The scales that the emote is available in.
+	 */
+	get scales(): HelixEmoteScale[] {
+		return this[rawDataSymbol].scale;
+	}
+
+	/**
+	 * The theme modes that the emote is available in.
+	 */
+	get themeModes(): HelixEmoteThemeMode[] {
+		return this[rawDataSymbol].theme_mode;
+	}
+
+	/**
 	 * Gets the URL of the emote image in the given scale.
 	 *
 	 * @param scale The scale of the image.
 	 */
 	getImageUrl(scale: HelixEmoteImageScale): string {
 		return this[rawDataSymbol].images[`url_${scale}x` as const];
+	}
+
+	/**
+	 * Gets the URL of the emote image in static format at the given scale, or null if a static emote image at that scale doesn't exist.
+	 *
+	 * @param scale The scale of the image.
+	 */
+	getStaticImageUrl(scale: HelixEmoteScale = '1.0'): string | null {
+		if (this[rawDataSymbol].format.includes('static') && this[rawDataSymbol].scale.includes(scale)) {
+			this.getFormattedImageUrl(scale, 'static');
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the URL of the emote image in animated format at the given scale, or null if an animated emote image at that scale doesn't exist.
+	 *
+	 * @param scale The scale of the image.
+	 */
+	getAnimatedImageUrl(scale: HelixEmoteScale = '1.0'): string | null {
+		if (this[rawDataSymbol].format.includes('animated') && this[rawDataSymbol].scale.includes(scale)) {
+			this.getFormattedImageUrl(scale, 'animated');
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the URL of the emote image in the given scale, format, and theme mode.
+	 *
+	 * @param scale The scale of the image, either `1.0` (small), `2.0` (medium), or `3.0` (large).
+	 * @param format The format of the image, either `static` or `animated`.
+	 * @param themeMode The theme mode of the image, either `light` or `dark`.
+	 */
+	getFormattedImageUrl(
+		scale: HelixEmoteScale = '1.0',
+		format: HelixEmoteFormat = 'static',
+		themeMode: HelixEmoteThemeMode = 'light'
+	): string {
+		return `https://static-cdn.jtvnw.net/emoticons/v2/${this[rawDataSymbol].id}/${format}/${themeMode}/${scale}`;
 	}
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -58,6 +58,9 @@ export { HelixPrivilegedChatSettings } from './api/helix/chat/HelixPrivilegedCha
 export type {
 	HelixChannelEmoteSubscriptionTier,
 	HelixEmoteImageScale,
+	HelixEmoteScale,
+	HelixEmoteFormat,
+	HelixEmoteThemeMode,
 	HelixChatUserColor,
 	HelixChatAnnouncementColor,
 	/** @deprecated */

--- a/packages/api/src/interfaces/helix/chat.external.ts
+++ b/packages/api/src/interfaces/helix/chat.external.ts
@@ -17,10 +17,22 @@ export interface HelixEmoteImageData {
 export type HelixEmoteImageScale = 1 | 2 | 4;
 
 /** @private */
+export type HelixEmoteFormat = 'static' | 'animated';
+
+/** @private */
+export type HelixEmoteScale = '1.0' | '2.0' | '3.0';
+
+/** @private */
+export type HelixEmoteThemeMode = 'light' | 'dark';
+
+/** @private */
 export interface HelixEmoteData {
 	id: string;
 	name: string;
 	images: HelixEmoteImageData;
+	format: HelixEmoteFormat[];
+	scale: HelixEmoteScale[];
+	theme_mode: HelixEmoteThemeMode[];
 }
 
 /** @private */


### PR DESCRIPTION
Type: Improvement

Fixes: #426

Adds missing fields to HelixEmote base object, supported by all 3 emote calls: global, channel, and set emotes.
