### PR TITLE
feat(pubsub): add subscription duration

### DIFF
--- a/packages/pubsub/src/messages/PubSubSubscriptionMessage.external.ts
+++ b/packages/pubsub/src/messages/PubSubSubscriptionMessage.external.ts
@@ -14,7 +14,6 @@ export interface PubSubSubscriptionGiftDetail {
 	recipient_user_name: string;
 	recipient_display_name: string;
 	months: number;
-	multi_month_duration: number;
 }
 
 /** @private */
@@ -23,4 +22,5 @@ export type PubSubSubscriptionMessageData = PubSubBasicMessageInfo & {
 	sub_plan: 'Prime' | '1000' | '2000' | '3000';
 	sub_plan_name: string;
 	sub_message: PubSubChatMessage;
+	multi_month_duration?: number;
 } & (PubSubSubscriptionDetail | PubSubSubscriptionGiftDetail);

--- a/packages/pubsub/src/messages/PubSubSubscriptionMessage.ts
+++ b/packages/pubsub/src/messages/PubSubSubscriptionMessage.ts
@@ -167,17 +167,12 @@ export class PubSubSubscriptionMessage extends DataObject<PubSubSubscriptionMess
 	}
 
 	/**
-	 * The duration of the gifted subscription, in months.
+	 * The duration of subscription, in months.
 	 *
-	 * Returns null if the subscription is not a gift.
+	 * This refers to first-time subscriptions, auto-renewal subscriptions, re-subscriptions, or gifted subscriptions.
 	 */
-	get giftDuration(): number | null {
-		const data = this[rawDataSymbol];
-		return data.context === 'subgift' ||
-			data.context === 'resubgift' ||
-			data.context === 'anonsubgift' ||
-			data.context === 'anonresubgift'
-			? data.multi_month_duration
-			: null;
+	get duration(): number {
+		// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+		return this[rawDataSymbol].multi_month_duration || 1;
 	}
 }


### PR DESCRIPTION
Type: Feature
Fixes: #437 

Removed `giftDuration` getter and created `duration` getter instead that refers to all subscription contexts.
All issue comments have been taken into account.
