### PR TITLE
add custom tag support, deprecate old tag system

### DIFF
--- a/packages/api/src/ApiClient.ts
+++ b/packages/api/src/ApiClient.ts
@@ -360,6 +360,8 @@ export class ApiClient {
 
 	/**
 	 * The Helix tag API methods.
+	 *
+	 * @deprecated
 	 */
 	@CachedGetter()
 	get tags(): HelixTagApi {

--- a/packages/api/src/api/helix/HelixApiGroup.ts
+++ b/packages/api/src/api/helix/HelixApiGroup.ts
@@ -172,6 +172,8 @@ export class HelixApiGroup extends BaseApi {
 
 	/**
 	 * The Helix tag API methods.
+	 *
+	 * @deprecated
 	 */
 	@CachedGetter()
 	get tags(): HelixTagApi {

--- a/packages/api/src/api/helix/channel/HelixChannel.ts
+++ b/packages/api/src/api/helix/channel/HelixChannel.ts
@@ -89,4 +89,11 @@ export class HelixChannel extends DataObject<HelixChannelData> {
 	get delay(): number {
 		return this[rawDataSymbol].delay;
 	}
+
+	/**
+	 * The tags applied to the channel.
+	 */
+	get tags(): string[] {
+		return this[rawDataSymbol].tags;
+	}
 }

--- a/packages/api/src/api/helix/search/HelixChannelSearchResult.ts
+++ b/packages/api/src/api/helix/search/HelixChannelSearchResult.ts
@@ -84,6 +84,8 @@ export class HelixChannelSearchResult extends DataObject<HelixChannelSearchResul
 
 	/**
 	 * The IDs of the tags set on the channel.
+	 *
+	 * @deprecated
 	 */
 	get tagIds(): string[] {
 		return this[rawDataSymbol].tag_ids;
@@ -91,9 +93,18 @@ export class HelixChannelSearchResult extends DataObject<HelixChannelSearchResul
 
 	/**
 	 * Retrieves the tags of the channel.
+	 *
+	 * @deprecated
 	 */
 	async getTags(): Promise<HelixTag[]> {
 		return await this._client.tags.getStreamTagsByIds(this[rawDataSymbol].tag_ids);
+	}
+
+	/**
+	 * The tags applied to the channel.
+	 */
+	get tags(): string[] {
+		return this[rawDataSymbol].tags;
 	}
 
 	/**

--- a/packages/api/src/api/helix/stream/HelixStream.ts
+++ b/packages/api/src/api/helix/stream/HelixStream.ts
@@ -133,6 +133,8 @@ export class HelixStream extends DataObject<HelixStreamData> {
 
 	/**
 	 * The IDs of the tags of the stream.
+	 *
+	 * @deprecated
 	 */
 	get tagIds(): string[] {
 		return this[rawDataSymbol].tag_ids ?? [];
@@ -140,9 +142,18 @@ export class HelixStream extends DataObject<HelixStreamData> {
 
 	/**
 	 * Retrieves the tags of the stream.
+	 *
+	 * @deprecated
 	 */
 	async getTags(): Promise<HelixTag[]> {
 		return await this._client.tags.getStreamTagsByIds(this[rawDataSymbol].tag_ids ?? []);
+	}
+
+	/**
+	 * The tags applied to the stream.
+	 */
+	get tags(): string[] {
+		return this[rawDataSymbol].tags;
 	}
 
 	/**

--- a/packages/api/src/api/helix/stream/HelixStreamApi.ts
+++ b/packages/api/src/api/helix/stream/HelixStreamApi.ts
@@ -207,6 +207,8 @@ export class HelixStreamApi extends BaseApi {
 	 * Retrieves the tags of a stream.
 	 *
 	 * @param broadcaster The broadcaster of the stream.
+	 *
+	 * @deprecated
 	 */
 	async getStreamTags(broadcaster: UserIdResolvable): Promise<HelixTag[]> {
 		const result = await this._client.callApi<HelixResponse<HelixTagData>>({
@@ -223,6 +225,8 @@ export class HelixStreamApi extends BaseApi {
 	 *
 	 * @param broadcaster The broadcaster of the stream.
 	 * @param tagIds The tags to set. If not given, removes all tags.
+	 *
+	 * @deprecated
 	 */
 	async replaceStreamTags(broadcaster: UserIdResolvable, tagIds?: string[]): Promise<void> {
 		await this._client.callApi({

--- a/packages/api/src/api/helix/tag/HelixTag.ts
+++ b/packages/api/src/api/helix/tag/HelixTag.ts
@@ -3,6 +3,8 @@ import { type HelixTagData } from '../../../interfaces/helix/tag.external';
 
 /**
  * A stream tag.
+ *
+ * @deprecated
  */
 @rtfm<HelixTag>('api', 'HelixTag', 'id')
 export class HelixTag extends DataObject<HelixTagData> {

--- a/packages/api/src/api/helix/tag/HelixTagApi.ts
+++ b/packages/api/src/api/helix/tag/HelixTagApi.ts
@@ -23,6 +23,8 @@ import { HelixTag } from './HelixTag';
  *
  * @meta category helix
  * @meta categorizedTitle Tags
+ *
+ * @deprecated
  */
 @rtfm('api', 'HelixTagApi')
 export class HelixTagApi extends BaseApi {
@@ -62,6 +64,8 @@ export class HelixTagApi extends BaseApi {
 	 * Retrieves a set of stream tags by IDs.
 	 *
 	 * @param ids The IDs of the stream tags.
+	 *
+	 * @deprecated
 	 */
 	async getStreamTagsByIds(ids: string[]): Promise<HelixTag[]> {
 		if (!ids.length) {
@@ -80,6 +84,8 @@ export class HelixTagApi extends BaseApi {
 	 * Retrieves a single stream tag by ID.
 	 *
 	 * @param id The ID of the stream tag.
+	 *
+	 * @deprecated
 	 */
 	async getStreamTagById(id: string): Promise<HelixTag | null> {
 		const tags = await this.getStreamTagsByIds([id]);

--- a/packages/api/src/api/helix/tag/HelixTagApi.ts
+++ b/packages/api/src/api/helix/tag/HelixTagApi.ts
@@ -32,6 +32,8 @@ export class HelixTagApi extends BaseApi {
 	 * @param pagination
 	 *
 	 * @expandParams
+	 *
+	 * @deprecated
 	 */
 	async getAllStreamTags(pagination?: HelixForwardPagination): Promise<HelixPaginatedResult<HelixTag>> {
 		const result = await this._client.callApi<HelixPaginatedResponse<HelixTagData>>({

--- a/packages/api/src/interfaces/helix/channel.external.ts
+++ b/packages/api/src/interfaces/helix/channel.external.ts
@@ -11,6 +11,7 @@ export interface HelixChannelData {
 	game_name: string;
 	title: string;
 	delay: number;
+	tags: string[];
 }
 
 /** @private */

--- a/packages/api/src/interfaces/helix/channel.input.ts
+++ b/packages/api/src/interfaces/helix/channel.input.ts
@@ -23,4 +23,12 @@ export interface HelixChannelUpdate {
 	 * Only works if you're a Twitch partner.
 	 */
 	delay?: number;
+
+	/**
+	 * A list of channel-defined tags to apply to the channel. To remove all tags from the channel, set tags to an empty array.
+	 *
+	 * A channel may specify a maximum of 10 tags. Each tag is limited to a maximum of 25 characters and may not be an empty string
+	 * or contain spaces or special characters. Tags are case insensitive.
+	 */
+	tags?: string[];
 }

--- a/packages/api/src/interfaces/helix/search.external.ts
+++ b/packages/api/src/interfaces/helix/search.external.ts
@@ -10,6 +10,7 @@ export interface HelixChannelSearchResultData {
 	game_name: string;
 	is_live: boolean;
 	tag_ids: string[];
+	tags: string[];
 	thumbnail_url: string;
 	title: string;
 	started_at: string;

--- a/packages/api/src/interfaces/helix/stream.external.ts
+++ b/packages/api/src/interfaces/helix/stream.external.ts
@@ -17,6 +17,7 @@ export interface HelixStreamData {
 	community_ids: string[];
 	type: HelixStreamType;
 	title: string;
+	tags: string[];
 	viewer_count: number;
 	started_at: string;
 	language: string;


### PR DESCRIPTION
Type: Feature

Fixes: Discord

Adds new custom tag fields and marks old tag fields/methods as deprecated