### PR TITLE
remove beta tag from Shield Mode endpoints/events

### DIFF
--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -570,7 +570,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.shield_mode.begin',
-			'beta',
+			'1',
 			createEventSubModeratorCondition(broadcaster, moderator),
 			transport,
 			'moderator:read:shield_mode'
@@ -591,7 +591,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.shield_mode.end',
-			'beta',
+			'1',
 			createEventSubModeratorCondition(broadcaster, moderator),
 			transport,
 			'moderator:read:shield_mode'

--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -562,8 +562,6 @@ export class HelixEventSubApi extends BaseApi {
 	 * @param broadcaster The broadcaster you want to listen to Shield Mode activation events for.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * @param transport The transport options.
-	 *
-	 * @beta
 	 */
 	async subscribeToChannelShieldModeBeginEvents(
 		broadcaster: UserIdResolvable,
@@ -585,8 +583,6 @@ export class HelixEventSubApi extends BaseApi {
 	 * @param broadcaster The broadcaster you want to listen to Shield Mode deactivation events for.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * @param transport The transport options.
-	 *
-	 * @beta
 	 */
 	async subscribeToChannelShieldModeEndEvents(
 		broadcaster: UserIdResolvable,

--- a/packages/api/src/api/helix/moderation/HelixModerationApi.ts
+++ b/packages/api/src/api/helix/moderation/HelixModerationApi.ts
@@ -451,8 +451,6 @@ export class HelixModerationApi extends BaseApi {
 	 * @param broadcaster The broadcaster whose Shield Mode activation status you want to get.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * This user must match the user associated with the user OAuth token.
-	 *
-	 * @beta
 	 */
 	async getShieldModeStatus(
 		broadcaster: UserIdResolvable,
@@ -476,8 +474,6 @@ export class HelixModerationApi extends BaseApi {
 	 * @param moderator A user that has permission to update Shield Mode status in the broadcaster's channel.
 	 * This user must match the user associated with the user OAuth token.
 	 * @param activate Whether or not to activate Shield Mode on the broadcaster's channel.
-	 *
-	 * @beta
 	 */
 	async updateShieldModeStatus(
 		broadcaster: UserIdResolvable,

--- a/packages/api/src/api/helix/moderation/HelixShieldModeStatus.ts
+++ b/packages/api/src/api/helix/moderation/HelixShieldModeStatus.ts
@@ -6,8 +6,6 @@ import type { HelixUser } from '../user/HelixUser';
 
 /**
  * Information about the Shield Mode status of a channel.
- *
- * @beta
  */
 @rtfm('api', 'HelixShieldModeStatus')
 export class HelixShieldModeStatus extends DataObject<HelixShieldModeStatusData> {

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -400,8 +400,6 @@ export abstract class EventSubBase extends EventEmitter {
 	 * @param broadcaster The user for which to get notifications for when Shield Mode is activated in their channel.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.
-	 *
-	 * @beta
 	 */
 	async subscribeToChannelShieldModeBeginEvents(
 		broadcaster: UserIdResolvable,
@@ -429,8 +427,6 @@ export abstract class EventSubBase extends EventEmitter {
 	 * @param broadcaster The user for which to get notifications for when Shield Mode is deactivated in their channel.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.
-	 *
-	 * @beta
 	 */
 	async subscribeToChannelShieldModeEndEvents(
 		broadcaster: UserIdResolvable,

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -229,8 +229,6 @@ export interface EventSubListener {
 	 * @param broadcaster The user for which to get notifications for when Shield Mode is activated in their channel.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.
-	 *
-	 * @beta
 	 */
 	subscribeToChannelShieldModeBeginEvents: (
 		broadcaster: UserIdResolvable,
@@ -244,8 +242,6 @@ export interface EventSubListener {
 	 * @param broadcaster The user for which to get notifications for when Shield Mode is deactivated in their channel.
 	 * @param moderator A user that has permission to read Shield Mode status in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.
-	 *
-	 * @beta
 	 */
 	subscribeToChannelShieldModeEndEvents: (
 		broadcaster: UserIdResolvable,

--- a/packages/eventsub-base/src/events/EventSubChannelShieldModeBeginEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelShieldModeBeginEvent.ts
@@ -5,8 +5,6 @@ import type { EventSubChannelShieldModeBeginEventData } from './EventSubChannelS
 
 /**
  * An EventSub event representing Shield Mode being activated on a broadcaster's channel.
- *
- * @beta
  */
 @rtfm('eventsub-base', 'EventSubChannelShieldModeBeginEvent')
 export class EventSubChannelShieldModeBeginEvent extends DataObject<EventSubChannelShieldModeBeginEventData> {

--- a/packages/eventsub-base/src/events/EventSubChannelShieldModeEndEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelShieldModeEndEvent.ts
@@ -5,8 +5,6 @@ import type { EventSubChannelShieldModeEndEventData } from './EventSubChannelShi
 
 /**
  * An EventSub event representing Shield Mode being deactivated on a broadcaster's channel.
- *
- * @beta
  */
 @rtfm('eventsub-base', 'EventSubChannelShieldModeEndEvent')
 export class EventSubChannelShieldModeEndEvent extends DataObject<EventSubChannelShieldModeEndEventData> {


### PR DESCRIPTION
Type: Improvement

Fixes: Discord

Removes beta tag from Shield Mode endpoints/events as this is now generally available from Twitch