### PR TITLE
Mark Charity as released, fix CLI names

### DIFF
--- a/packages/api/src/ApiClient.ts
+++ b/packages/api/src/ApiClient.ts
@@ -230,8 +230,6 @@ export class ApiClient {
 
 	/**
 	 * The Helix charity API methods.
-	 *
-	 * @beta
 	 */
 	@CachedGetter()
 	get charity(): HelixCharityApi {

--- a/packages/api/src/api/helix/charity/HelixCharityApi.ts
+++ b/packages/api/src/api/helix/charity/HelixCharityApi.ts
@@ -25,7 +25,6 @@ import { HelixCharityCampaignDonation } from './HelixCharityCampaignDonation';
  * const charityCampaign = await api.charity.getCharityCampaign('125328655');
  * ```
  *
- * @beta
  * @meta category helix
  * @meta categorizedTitle Charity Campaigns
  */
@@ -35,7 +34,6 @@ export class HelixCharityApi extends BaseApi {
 	 * Gets information about the charity campaign that a broadcaster is running.
 	 * Returns null if the specified broadcaster has no active charity campaign.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster to get charity campaign information about.
 	 */
 	async getCharityCampaign(broadcaster: UserIdResolvable): Promise<HelixCharityCampaign> {
@@ -53,7 +51,6 @@ export class HelixCharityApi extends BaseApi {
 	/**
 	 * Gets the list of donations that users have made to the broadcaster’s active charity campaign.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster to get charity campaign donation information about.
 	 * @param pagination
 	 *

--- a/packages/api/src/api/helix/charity/HelixCharityCampaign.ts
+++ b/packages/api/src/api/helix/charity/HelixCharityCampaign.ts
@@ -7,8 +7,6 @@ import { HelixCharityCampaignAmount } from './HelixCharityCampaignAmount';
 
 /**
  * A charity campaign in a Twitch channel.
- *
- * @beta
  */
 @rtfm<HelixCharityCampaign>('api', 'HelixCharityCampaign', 'id')
 export class HelixCharityCampaign extends DataObject<HelixCharityCampaignData> {

--- a/packages/api/src/api/helix/charity/HelixCharityCampaignAmount.ts
+++ b/packages/api/src/api/helix/charity/HelixCharityCampaignAmount.ts
@@ -3,8 +3,6 @@ import { type HelixCharityCampaignAmountData } from '../../../interfaces/helix/c
 
 /**
  * An object representing monetary amount and currency information for charity donations/goals.
- *
- * @beta
  */
 @rtfm('api', 'HelixCharityCampaignAmount')
 export class HelixCharityCampaignAmount extends DataObject<HelixCharityCampaignAmountData> {

--- a/packages/api/src/api/helix/charity/HelixCharityCampaignDonation.ts
+++ b/packages/api/src/api/helix/charity/HelixCharityCampaignDonation.ts
@@ -7,8 +7,6 @@ import { HelixCharityCampaignAmount } from './HelixCharityCampaignAmount';
 
 /**
  * A donation to a charity campaign in a Twitch channel.
- *
- * @beta
  */
 @rtfm('api', 'HelixCharityCampaignDonation')
 export class HelixCharityCampaignDonation extends DataObject<HelixCharityCampaignDonationData> {

--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -450,7 +450,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.charity_campaign.start',
-			'beta',
+			'1',
 			createEventSubBroadcasterCondition(broadcaster),
 			transport,
 			'channel:read:charity'
@@ -469,7 +469,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.charity_campaign.stop',
-			'beta',
+			'1',
 			createEventSubBroadcasterCondition(broadcaster),
 			transport,
 			'channel:read:charity'
@@ -488,7 +488,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.charity_campaign.donate',
-			'beta',
+			'1',
 			createEventSubBroadcasterCondition(broadcaster),
 			transport,
 			'channel:read:charity'
@@ -507,7 +507,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.charity_campaign.progress',
-			'beta',
+			'1',
 			createEventSubBroadcasterCondition(broadcaster),
 			transport,
 			'channel:read:charity'

--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -441,7 +441,6 @@ export class HelixEventSubApi extends BaseApi {
 	/**
 	 * Subscribe to events that represent a charity campaign starting in a channel.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster you want to listen to charity donation events for.
 	 * @param transport The transport option.
 	 */
@@ -461,7 +460,6 @@ export class HelixEventSubApi extends BaseApi {
 	/**
 	 * Subscribe to events that represent a charity campaign ending in a channel.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster you want to listen to charity donation events for.
 	 * @param transport The transport option.
 	 */
@@ -481,7 +479,6 @@ export class HelixEventSubApi extends BaseApi {
 	/**
 	 * Subscribe to events that represent a user donating to a charity campaign in a channel.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster you want to listen to charity donation events for.
 	 * @param transport The transport option.
 	 */
@@ -501,7 +498,6 @@ export class HelixEventSubApi extends BaseApi {
 	/**
 	 * Subscribe to events that represent a charity campaign progressing in a channel.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster you want to listen to charity donation events for.
 	 * @param transport The transport option.
 	 */

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -303,7 +303,6 @@ export abstract class EventSubBase extends EventEmitter {
 	/**
 	 * Subscribes to events that represent a charity campaign starting in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaigns starting.
 	 * @param handler The function that will be called for any new notifications.
 	 */
@@ -319,7 +318,6 @@ export abstract class EventSubBase extends EventEmitter {
 	/**
 	 * Subscribes to events that represent a charity campaign ending in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaigns ending.
 	 * @param handler The function that will be called for any new notifications.
 	 */
@@ -335,7 +333,6 @@ export abstract class EventSubBase extends EventEmitter {
 	/**
 	 * Subscribes to events that represent a donation to a charity campaign in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaign donations.
 	 * @param handler The function that will be called for any new notifications.
 	 */
@@ -351,7 +348,6 @@ export abstract class EventSubBase extends EventEmitter {
 	/**
 	 * Subscribes to events that represent progress in a charity campaign in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaign progress.
 	 * @param handler The function that will be called for any new notifications.
 	 */

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -156,7 +156,6 @@ export interface EventSubListener {
 	/**
 	 * Subscribes to events that represent a charity campaign starting in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaigns starting.
 	 * @param handler The function that will be called for any new notifications.
 	 */
@@ -168,7 +167,6 @@ export interface EventSubListener {
 	/**
 	 * Subscribes to events that represent a charity campaign ending in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaigns ending.
 	 * @param handler The function that will be called for any new notifications.
 	 */
@@ -180,7 +178,6 @@ export interface EventSubListener {
 	/**
 	 * Subscribes to events that represent a donation to a charity campaign in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaign donations.
 	 * @param handler The function that will be called for any new notifications.
 	 */
@@ -192,7 +189,6 @@ export interface EventSubListener {
 	/**
 	 * Subscribes to events that represent progress in a charity campaign in a channel.
 	 *
-	 * @beta
 	 * @param user The user for which to get notifications about charity campaign progress.
 	 * @param handler The function that will be called for any new notifications.
 	 */

--- a/packages/eventsub-base/src/events/EventSubChannelCharityCampaignProgressEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelCharityCampaignProgressEvent.ts
@@ -6,8 +6,6 @@ import { type EventSubChannelCharityCampaignProgressEventData } from './EventSub
 
 /**
  * An EventSub event representing progress of a charity campaign in a channel.
- *
- * @beta
  */
 @rtfm<EventSubChannelCharityCampaignProgressEvent>('eventsub-base', 'EventSubChannelCharityCampaignProgressEvent', 'id')
 export class EventSubChannelCharityCampaignProgressEvent extends DataObject<EventSubChannelCharityCampaignProgressEventData> {

--- a/packages/eventsub-base/src/events/EventSubChannelCharityCampaignStartEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelCharityCampaignStartEvent.ts
@@ -6,8 +6,6 @@ import { type EventSubChannelCharityCampaignStartEventData } from './EventSubCha
 
 /**
  * An EventSub event representing the start of a charity campaign in a channel.
- *
- * @beta
  */
 @rtfm<EventSubChannelCharityCampaignStartEvent>('eventsub-base', 'EventSubChannelCharityCampaignStartEvent', 'id')
 export class EventSubChannelCharityCampaignStartEvent extends DataObject<EventSubChannelCharityCampaignStartEventData> {

--- a/packages/eventsub-base/src/events/EventSubChannelCharityCampaignStopEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelCharityCampaignStopEvent.ts
@@ -6,8 +6,6 @@ import { type EventSubChannelCharityCampaignStopEventData } from './EventSubChan
 
 /**
  * An EventSub event representing the end of a charity campaign in a channel.
- *
- * @beta
  */
 @rtfm<EventSubChannelCharityCampaignStopEvent>('eventsub-base', 'EventSubChannelCharityCampaignStopEvent', 'id')
 export class EventSubChannelCharityCampaignStopEvent extends DataObject<EventSubChannelCharityCampaignStopEventData> {

--- a/packages/eventsub-base/src/events/EventSubChannelCharityDonationEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelCharityDonationEvent.ts
@@ -6,8 +6,6 @@ import { type EventSubChannelCharityDonationEventData } from './EventSubChannelC
 
 /**
  * An EventSub event representing a donation to a charity campaign in a channel.
- *
- * @beta
  */
 @rtfm<EventSubChannelCharityDonationEvent>('eventsub-base', 'EventSubChannelCharityDonationEvent', 'broadcasterId')
 export class EventSubChannelCharityDonationEvent extends DataObject<EventSubChannelCharityDonationEventData> {

--- a/packages/eventsub-base/src/events/common/EventSubChannelCharityAmount.ts
+++ b/packages/eventsub-base/src/events/common/EventSubChannelCharityAmount.ts
@@ -3,8 +3,6 @@ import { type EventSubChannelCharityAmountData } from './EventSubChannelCharityA
 
 /**
  * An object representing monetary amount and currency information for charity donations/goals.
- *
- * @beta
  */
 @rtfm('eventsub-base', 'EventSubChannelCharityAmount')
 export class EventSubChannelCharityAmount extends DataObject<EventSubChannelCharityAmountData> {

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelCharityCampaignProgressSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelCharityCampaignProgressSubscription.ts
@@ -10,7 +10,7 @@ import { EventSubSubscription } from './EventSubSubscription';
  */
 @rtfm('eventsub-base', 'EventSubSubscription')
 export class EventSubChannelCharityCampaignProgressSubscription extends EventSubSubscription<EventSubChannelCharityCampaignProgressEvent> {
-	/** @protected */ readonly _cliName = 'charity-campaign-progress';
+	/** @protected */ readonly _cliName = 'charity-progress';
 
 	constructor(
 		handler: (data: EventSubChannelCharityCampaignProgressEvent) => void,

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelCharityCampaignStartSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelCharityCampaignStartSubscription.ts
@@ -10,7 +10,7 @@ import { EventSubSubscription } from './EventSubSubscription';
  */
 @rtfm('eventsub-base', 'EventSubSubscription')
 export class EventSubChannelCharityCampaignStartSubscription extends EventSubSubscription<EventSubChannelCharityCampaignStartEvent> {
-	/** @protected */ readonly _cliName = 'charity-campaign-start';
+	/** @protected */ readonly _cliName = 'charity-start';
 
 	constructor(
 		handler: (data: EventSubChannelCharityCampaignStartEvent) => void,

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelCharityCampaignStopSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelCharityCampaignStopSubscription.ts
@@ -10,7 +10,7 @@ import { EventSubSubscription } from './EventSubSubscription';
  */
 @rtfm('eventsub-base', 'EventSubSubscription')
 export class EventSubChannelCharityCampaignStopSubscription extends EventSubSubscription<EventSubChannelCharityCampaignStopEvent> {
-	/** @protected */ readonly _cliName = 'charity-campaign-stop';
+	/** @protected */ readonly _cliName = 'charity-stop';
 
 	constructor(
 		handler: (data: EventSubChannelCharityCampaignStopEvent) => void,

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelCharityDonationSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelCharityDonationSubscription.ts
@@ -10,7 +10,7 @@ import { EventSubSubscription } from './EventSubSubscription';
  */
 @rtfm('eventsub-base', 'EventSubSubscription')
 export class EventSubChannelCharityDonationSubscription extends EventSubSubscription<EventSubChannelCharityDonationEvent> {
-	/** @protected */ readonly _cliName = 'charity-campaign-donate';
+	/** @protected */ readonly _cliName = 'charity-donation';
 
 	constructor(
 		handler: (data: EventSubChannelCharityDonationEvent) => void,


### PR DESCRIPTION
Type: Feature

Fixes: Discord

Removes beta indicators for charity Helix endpoints/EventSub events as these have been marked as GA. Also fixes charity event CLI names.