### PR TITLE
clear beta tag from GA items (shoutouts, chatters)

### DIFF
--- a/packages/api/src/api/helix/chat/HelixChatApi.ts
+++ b/packages/api/src/api/helix/chat/HelixChatApi.ts
@@ -311,7 +311,6 @@ export class HelixChatApi extends BaseApi {
 	 * Sends a shoutout to the specified broadcaster.
 	 * The broadcaster may send a shoutout once every 2 minutes. They may send the same broadcaster a shoutout once every 60 minutes.
 	 *
-	 * @beta
 	 * @param from The ID of the broadcaster that’s sending the shoutout.
 	 * @param to The ID of the broadcaster that’s receiving the shoutout.
 	 * @param moderator The ID of the broadcaster or a user that is one of the broadcaster’s moderators.

--- a/packages/api/src/api/helix/chat/HelixChatChatter.ts
+++ b/packages/api/src/api/helix/chat/HelixChatChatter.ts
@@ -6,8 +6,6 @@ import { type HelixUser } from '../user/HelixUser';
 
 /**
  * A user connected to a Twitch channel's chat session.
- *
- * @beta
  */
 @rtfm('api', 'HelixChatChatter')
 export class HelixChatChatter extends DataObject<HelixChatChatterData> {

--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -1160,7 +1160,6 @@ export class HelixEventSubApi extends BaseApi {
 	/**
 	 * Subscribe to events that represent a broadcaster shouting out another broadcaster.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster for which you want to listen to outgoing shoutout events.
 	 * @param moderator A user that has permission to see or manage shoutout events in the broadcaster's channel.
 	 * @param transport The transport options.
@@ -1183,7 +1182,6 @@ export class HelixEventSubApi extends BaseApi {
 	/**
 	 * Subscribe to events that represent a broadcaster being shouting out by another broadcaster.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster for which you want to listen to incoming shoutout events.
 	 * @param moderator A user that has permission to see or manage shoutout events in the broadcaster's channel.
 	 * @param transport The transport options.

--- a/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/api/helix/eventSub/HelixEventSubApi.ts
@@ -1171,7 +1171,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.shoutout.create',
-			'beta',
+			'1',
 			createEventSubModeratorCondition(broadcaster, moderator),
 			transport,
 			broadcaster,
@@ -1193,7 +1193,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.shoutout.receive',
-			'beta',
+			'1',
 			createEventSubModeratorCondition(broadcaster, moderator),
 			transport,
 			broadcaster,

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -864,7 +864,6 @@ export abstract class EventSubBase extends EventEmitter {
 	/**
 	 * Subscribes to events that represent a broadcaster shouting out another broadcaster.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster for which you want to listen to outgoing shoutout events.
 	 * @param moderator A user that has permission to see or manage shoutout events in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.
@@ -892,7 +891,6 @@ export abstract class EventSubBase extends EventEmitter {
 	/**
 	 * Subscribes to events that represent a broadcaster being shouted out by another broadcaster.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster for which you want to listen to incoming shoutout events.
 	 * @param moderator A user that has permission to see or manage shoutout events in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -543,7 +543,6 @@ export interface EventSubListener {
 	/**
 	 * Subscribes to events that represent a broadcaster shouting out another broadcaster.
 	 *
-	 * @beta
 	 * @param broadcaster The broadcaster for which you want to listen to outgoing shoutout events.
 	 * @param moderator A user that has permission to see or manage shoutout events in the broadcaster's channel.
 	 * @param handler The function that will be called for any new notifications.
@@ -556,8 +555,6 @@ export interface EventSubListener {
 
 	/**
 	 * Subscribes to events that represent a broadcaster being shouted out by another broadcaster.
-	 *
-	 * @beta
 	 *
 	 * @param broadcaster The broadcaster for which you want to listen to incoming shoutout events.
 	 * @param moderator A user that has permission to see or manage shoutout events in the broadcaster's channel.

--- a/packages/eventsub-base/src/events/EventSubChannelShoutoutCreateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelShoutoutCreateEvent.ts
@@ -5,8 +5,6 @@ import { type EventSubChannelShoutoutCreateEventData } from './EventSubChannelSh
 
 /**
  * An EventSub event representing a broadcaster shouting out another broadcaster.
- *
- * @beta
  */
 @rtfm<EventSubChannelShoutoutCreateEvent>(
 	'eventsub-base',

--- a/packages/eventsub-base/src/events/EventSubChannelShoutoutReceiveEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelShoutoutReceiveEvent.ts
@@ -5,8 +5,6 @@ import { type EventSubChannelShoutoutReceiveEventData } from './EventSubChannelS
 
 /**
  * An EventSub event representing a broadcaster being shouted out by another broadcaster.
- *
- * @beta
  */
 @rtfm<EventSubChannelShoutoutReceiveEvent>(
 	'eventsub-base',


### PR DESCRIPTION
Type: Feature

Fixes: Discord

Remove `@beta` tags from now GA shoutout events/endpoint, and one that was still on the `HelixChatChatter` object.
