### PR TITLE
pubsub: add support for low-trust users events

### DIFF
--- a/docs/getting-data/index.md
+++ b/docs/getting-data/index.md
@@ -54,25 +54,26 @@ should use for which use case.
 
 ## Events
 
-| Event type                        | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub-*`     |
-|-----------------------------------|------------------------------|---------------------------|---------------------------|
-| Chat messages                     | Yes                          | Sub & cheer messages only | Sub & cheer messages only |
-| Chat mode (e.g. sub only) changes | Yes                          | No                        | No                        |
-| Whispers                          | Yes                          | Yes                       | No                        |
-| Cheers                            | Yes                          | Yes                       | Yes                       |
-| Channel points                    | Redemptions w/ messages only | Redemptions only          | Yes                       |
-| Subscriptions                     | Published only               | Published only            | Yes                       |
-| AutoMod                           | No                           | Yes                       | No                        |
-| Live / offline / stream changes   | No                           | No                        | Yes                       |
-| Follows                           | No                           | No                        | Yes                       |
-| Raids                             | Yes                          | No                        | Yes                       |
-| Bans                              | Yes                          | Yes                       | Yes                       |
-| Mod add/remove                    | No                           | Yes                       | Yes                       |
-| Polls & predictions               | No                           | No                        | Yes                       |
-| Extension transactions            | No                           | No                        | Yes                       |
-| Hype Trains                       | No                           | No                        | Yes                       |
-| Authorization grant/revoke        | No                           | No                        | Yes                       |
-| Drops                             | No                           | No                        | Yes                       |
-| Charity campaigns & donations     | No                           | No                        | Yes                       |
-| Shield mode begin/end             | No                           | No                        | Yes                       |
-| Unban request approve/deny        | No                           | Yes                       | No                        |
+| Event type                             | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub-*`     |
+|----------------------------------------|------------------------------|---------------------------|---------------------------|
+| Chat messages                          | Yes                          | Sub & cheer messages only | Sub & cheer messages only |
+| Chat mode (e.g. sub only) changes      | Yes                          | No                        | No                        |
+| Whispers                               | Yes                          | Yes                       | No                        |
+| Cheers                                 | Yes                          | Yes                       | Yes                       |
+| Channel points                         | Redemptions w/ messages only | Redemptions only          | Yes                       |
+| Subscriptions                          | Published only               | Published only            | Yes                       |
+| AutoMod                                | No                           | Yes                       | No                        |
+| Live / offline / stream changes        | No                           | No                        | Yes                       |
+| Follows                                | No                           | No                        | Yes                       |
+| Raids                                  | Yes                          | No                        | Yes                       |
+| Bans                                   | Yes                          | Yes                       | Yes                       |
+| Mod add/remove                         | No                           | Yes                       | Yes                       |
+| Polls & predictions                    | No                           | No                        | Yes                       |
+| Extension transactions                 | No                           | No                        | Yes                       |
+| Hype Trains                            | No                           | No                        | Yes                       |
+| Authorization grant/revoke             | No                           | No                        | Yes                       |
+| Drops                                  | No                           | No                        | Yes                       |
+| Charity campaigns & donations          | No                           | No                        | Yes                       |
+| Shield mode begin/end                  | No                           | No                        | Yes                       |
+| Unban request approve/deny             | No                           | Yes                       | No                        |
+| Low-trust users treatment/chat message | No                           | Yes                       | No                        |

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -19,7 +19,7 @@ export type {
 	PubSubUnlistenPacket
 } from './PubSubPacket.external';
 
-export type { PubSubMessage } from './messages/PubSubMessage';
+export type { PubSubMessage, PubSubLowTrustUserMessage } from './messages/PubSubMessage';
 export { PubSubAutoModQueueMessage } from './messages/PubSubAutoModQueueMessage';
 export { PubSubBitsMessage } from './messages/PubSubBitsMessage';
 export { PubSubBitsBadgeUnlockMessage } from './messages/PubSubBitsBadgeUnlockMessage';
@@ -28,6 +28,17 @@ export { type PubSubChannelRoleChangeType } from './messages/PubSubChannelRoleCh
 export { PubSubChannelTermsActionMessage } from './messages/PubSubChannelTermsActionMessage';
 export { PubSubChatModActionMessage } from './messages/PubSubChatModActionMessage';
 export { PubSubCustomMessage } from './messages/PubSubCustomMessage';
+export {
+	type PubSubLowTrustUserTreatmentType,
+	type PubSubLowTrustUserBanEvasionEvaluationType,
+	type PubSubLowTrustUserType
+} from './messages/common/PubSubLowTrustUserContentBase.external';
+export { PubSubLowTrustUserTreatmentMessage } from './messages/PubSubLowTrustUserTreatmentMessage';
+export {
+	type PubSubLowTrustUserTreatmentChatMessageContentFragmentEmoteData,
+	type PubSubLowTrustUserChatMessageContentFragmentData
+} from './messages/PubSubLowTrustUserChatMessage.external';
+export { PubSubLowTrustUserChatMessage } from './messages/PubSubLowTrustUserChatMessage';
 export { PubSubRedemptionMessage } from './messages/PubSubRedemptionMessage';
 export { PubSubSubscriptionMessage } from './messages/PubSubSubscriptionMessage';
 export { PubSubUnbanRequestMessage } from './messages/PubSubUnbanRequestMessage';

--- a/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.external.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.external.ts
@@ -1,0 +1,47 @@
+import { type PubSubLowTrustUserContentBase } from './common/PubSubLowTrustUserContentBase.external';
+
+/**
+ * Emote data of a chat message fragment.
+ */
+export interface PubSubLowTrustUserTreatmentChatMessageContentFragmentEmoteData {
+	emoticonID: string;
+	emoticonSetID: string;
+}
+
+/**
+ * A text fragment of a chat message from a low-trust user.
+ *
+ * Contains emote data if the fragment is a chat emote.
+ */
+export interface PubSubLowTrustUserChatMessageContentFragmentData {
+	text: string;
+	emoticon?: PubSubLowTrustUserTreatmentChatMessageContentFragmentEmoteData;
+}
+
+/** @private */
+export interface PubSubLowTrustUserChatMessageTreatmentContent extends PubSubLowTrustUserContentBase {
+	id: string;
+	sender: {
+		user_id: string;
+		login: string;
+		display_name: string;
+	};
+	shared_ban_channel_ids: string[] | null;
+}
+
+/** @private */
+export interface PubSubLowTrustUserChatMessageContent {
+	low_trust_user: PubSubLowTrustUserChatMessageTreatmentContent;
+	message_content: {
+		text: string;
+		fragments: PubSubLowTrustUserChatMessageContentFragmentData[];
+	};
+	message_id: string;
+	sent_at: string;
+}
+
+/** @private */
+export interface PubSubLowTrustUserChatMessageData {
+	type: 'low_trust_user_new_message';
+	data: PubSubLowTrustUserChatMessageContent;
+}

--- a/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
@@ -1,0 +1,152 @@
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import {
+	type PubSubLowTrustUserChatMessageData,
+	type PubSubLowTrustUserChatMessageContentFragmentData
+} from './PubSubLowTrustUserChatMessage.external';
+import {
+	type PubSubLowTrustUserBanEvasionEvaluationType,
+	type PubSubLowTrustUserTreatmentType,
+	type PubSubLowTrustUserType
+} from './common/PubSubLowTrustUserContentBase.external';
+
+/**
+ * A message that informs about a new chat message from a low-trust user.
+ */
+@rtfm<PubSubLowTrustUserChatMessage>('pubsub', 'PubSubLowTrustUserChatMessage', 'lowTrustId')
+export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUserChatMessageData> {
+	/**
+	 * The ID of the channel where the suspicious user was present.
+	 */
+	get channelId(): string {
+		return this[rawDataSymbol].data.low_trust_user.channel_id;
+	}
+
+	/**
+	 * Unique ID for this low trust chat message.
+	 */
+	get lowTrustId(): string {
+		return this[rawDataSymbol].data.low_trust_user.low_trust_id;
+	}
+
+	/**
+	 * The user ID of the moderator.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].data.low_trust_user.updated_by.id;
+	}
+
+	/**
+	 * The name of the moderator.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].data.low_trust_user.updated_by.login;
+	}
+
+	/**
+	 * The display name of the moderator.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].data.low_trust_user.updated_by.display_name;
+	}
+
+	/**
+	 * The date of when the treatment was updated for the suspicious user.
+	 */
+	get updateDate(): Date {
+		return new Date(this[rawDataSymbol].data.low_trust_user.updated_at);
+	}
+
+	/**
+	 * The user ID of the suspicious user.
+	 */
+	get senderUserId(): string {
+		return this[rawDataSymbol].data.low_trust_user.sender.user_id;
+	}
+
+	/**
+	 * The name of the suspicious user.
+	 */
+	get senderUserName(): string {
+		return this[rawDataSymbol].data.low_trust_user.sender.login;
+	}
+
+	/**
+	 * The display name of the suspicious user.
+	 */
+	get senderDisplayName(): string {
+		return this[rawDataSymbol].data.low_trust_user.sender.display_name;
+	}
+
+	/**
+	 * The treatment set for the suspicious user.
+	 */
+	get treatment(): PubSubLowTrustUserTreatmentType {
+		return this[rawDataSymbol].data.low_trust_user.treatment;
+	}
+
+	/**
+	 * User types (if any) that apply to the suspicious user.
+	 */
+	get types(): PubSubLowTrustUserType[] {
+		return this[rawDataSymbol].data.low_trust_user.types;
+	}
+
+	/**
+	 * The ban evasion likelihood value that as been applied to the user automatically by Twitch.
+	 *
+	 * Can be an empty string.
+	 */
+	get banEvasionEvaluation(): PubSubLowTrustUserBanEvasionEvaluationType {
+		return this[rawDataSymbol].data.low_trust_user.ban_evasion_evaluation;
+	}
+
+	/**
+	 * The date for the first time the suspicious user was automatically evaluated by Twitch.
+	 *
+	 * Will be `null` if {@link PubSubLowTrustUserTreatmentMessage#banEvasionEvaluation} is empty.
+	 */
+	get evaluationDate(): Date | null {
+		// PubSub sends `0001-01-01T00:00:00.000Z` string
+		// if the field is not applicable
+		const date = this[rawDataSymbol].data.low_trust_user.evaluated_at
+			? new Date(this[rawDataSymbol].data.low_trust_user.evaluated_at)
+			: undefined;
+
+		return date && date.getTime() > 0 ? date : null;
+	}
+
+	/**
+	 * A list of channel IDs where the suspicious user is also banned.
+	 */
+	get sharedBanChannelIds(): string[] | null {
+		return this[rawDataSymbol].data.low_trust_user.shared_ban_channel_ids;
+	}
+
+	/**
+	 * The ID of the chat message.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].data.message_id;
+	}
+
+	/**
+	 * Plain text of the message sent.
+	 */
+	get content(): string {
+		return this[rawDataSymbol].data.message_content.text;
+	}
+
+	/**
+	 * Fragments contained in the message, including emotes.
+	 */
+	get fragments(): PubSubLowTrustUserChatMessageContentFragmentData[] {
+		return this[rawDataSymbol].data.message_content.fragments;
+	}
+
+	/**
+	 * Date when the chat message was sent.
+	 */
+	get sendDate(): Date {
+		return new Date(this[rawDataSymbol].data.sent_at);
+	}
+}

--- a/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
@@ -22,7 +22,7 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	}
 
 	/**
-	 * Unique ID for this low trust chat message.
+	 * Unique ID for this low-trust chat message.
 	 */
 	get lowTrustId(): string {
 		return this[rawDataSymbol].data.low_trust_user.low_trust_id;
@@ -118,8 +118,8 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	/**
 	 * A list of channel IDs where the suspicious user is also banned.
 	 */
-	get sharedBanChannelIds(): string[] | null {
-		return this[rawDataSymbol].data.low_trust_user.shared_ban_channel_ids;
+	get sharedBanChannelIds(): string[] {
+		return this[rawDataSymbol].data.low_trust_user.shared_ban_channel_ids ?? [];
 	}
 
 	/**

--- a/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
@@ -22,7 +22,7 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	}
 
 	/**
-	 * Unique ID for this low-trust chat message.
+	 * The unique ID of this low-trust event.
 	 */
 	get lowTrustId(): string {
 		return this[rawDataSymbol].data.low_trust_user.low_trust_id;
@@ -94,7 +94,7 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	/**
 	 * The ban evasion likelihood value that as been applied to the user automatically by Twitch.
 	 *
-	 * Can be an empty string.
+	 * Can be an empty string if Twitch did not apply any evasion value.
 	 */
 	get banEvasionEvaluation(): PubSubLowTrustUserBanEvasionEvaluationType {
 		return this[rawDataSymbol].data.low_trust_user.ban_evasion_evaluation;
@@ -103,11 +103,10 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	/**
 	 * The date for the first time the suspicious user was automatically evaluated by Twitch.
 	 *
-	 * Will be `null` if {@link PubSubLowTrustUserTreatmentMessage#banEvasionEvaluation} is empty.
+	 * Will be `null` if {@link PubSubLowTrustUserChatMessage#banEvasionEvaluation} is empty.
 	 */
 	get evaluationDate(): Date | null {
-		// PubSub sends `0001-01-01T00:00:00.000Z` string
-		// if the field is not applicable
+		// PubSub sends `0001-01-01T00:00:00.000Z` string if the field is not applicable
 		const date = this[rawDataSymbol].data.low_trust_user.evaluated_at
 			? new Date(this[rawDataSymbol].data.low_trust_user.evaluated_at)
 			: undefined;

--- a/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserChatMessage.ts
@@ -31,21 +31,21 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	/**
 	 * The user ID of the moderator.
 	 */
-	get userId(): string {
+	get moderatorId(): string {
 		return this[rawDataSymbol].data.low_trust_user.updated_by.id;
 	}
 
 	/**
 	 * The name of the moderator.
 	 */
-	get userName(): string {
+	get moderatorName(): string {
 		return this[rawDataSymbol].data.low_trust_user.updated_by.login;
 	}
 
 	/**
 	 * The display name of the moderator.
 	 */
-	get userDisplayName(): string {
+	get moderatorDisplayName(): string {
 		return this[rawDataSymbol].data.low_trust_user.updated_by.display_name;
 	}
 
@@ -59,21 +59,21 @@ export class PubSubLowTrustUserChatMessage extends DataObject<PubSubLowTrustUser
 	/**
 	 * The user ID of the suspicious user.
 	 */
-	get senderUserId(): string {
+	get userId(): string {
 		return this[rawDataSymbol].data.low_trust_user.sender.user_id;
 	}
 
 	/**
 	 * The name of the suspicious user.
 	 */
-	get senderUserName(): string {
+	get userName(): string {
 		return this[rawDataSymbol].data.low_trust_user.sender.login;
 	}
 
 	/**
 	 * The display name of the suspicious user.
 	 */
-	get senderDisplayName(): string {
+	get userDisplayName(): string {
 		return this[rawDataSymbol].data.low_trust_user.sender.display_name;
 	}
 

--- a/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.external.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.external.ts
@@ -1,0 +1,13 @@
+import { type PubSubLowTrustUserContentBase } from './common/PubSubLowTrustUserContentBase.external';
+
+/** @private */
+export interface PubSubLowTrustUserTreatmentMessageContent extends PubSubLowTrustUserContentBase {
+	target_user_id: string;
+	target_user: string;
+}
+
+/** @private */
+export interface PubSubLowTrustUserTreatmentMessageData {
+	type: 'low_trust_user_treatment_update';
+	data: PubSubLowTrustUserTreatmentMessageContent;
+}

--- a/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.ts
@@ -29,21 +29,21 @@ export class PubSubLowTrustUserTreatmentMessage extends DataObject<PubSubLowTrus
 	/**
 	 * The user ID of the moderator.
 	 */
-	get userId(): string {
+	get moderatorId(): string {
 		return this[rawDataSymbol].data.updated_by.id;
 	}
 
 	/**
 	 * The name of the moderator.
 	 */
-	get userName(): string {
+	get moderatorName(): string {
 		return this[rawDataSymbol].data.updated_by.login;
 	}
 
 	/**
 	 * The display name of the moderator.
 	 */
-	get userDisplayName(): string {
+	get moderatorDisplayName(): string {
 		return this[rawDataSymbol].data.updated_by.display_name;
 	}
 
@@ -57,14 +57,14 @@ export class PubSubLowTrustUserTreatmentMessage extends DataObject<PubSubLowTrus
 	/**
 	 * The user ID of the suspicious user
 	 */
-	get targetUserId(): string {
+	get userId(): string {
 		return this[rawDataSymbol].data.target_user_id;
 	}
 
 	/**
 	 * The name of the suspicious user.
 	 */
-	get targetUserName(): string {
+	get userName(): string {
 		return this[rawDataSymbol].data.target_user;
 	}
 

--- a/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.ts
@@ -1,0 +1,108 @@
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type PubSubLowTrustUserTreatmentMessageData } from './PubSubLowTrustUserTreatmentMessage.external';
+import {
+	type PubSubLowTrustUserBanEvasionEvaluationType,
+	type PubSubLowTrustUserTreatmentType,
+	type PubSubLowTrustUserType
+} from './common/PubSubLowTrustUserContentBase.external';
+
+/**
+ * A message that informs about treatment against a low-trust user.
+ */
+@rtfm<PubSubLowTrustUserTreatmentMessage>('pubsub', 'PubSubLowTrustUserTreatmentMessage', 'lowTrustId')
+export class PubSubLowTrustUserTreatmentMessage extends DataObject<PubSubLowTrustUserTreatmentMessageData> {
+	/**
+	 * The ID of the channel where the suspicious user was present.
+	 */
+	get channelId(): string {
+		return this[rawDataSymbol].data.channel_id;
+	}
+
+	/**
+	 * The ID for the suspicious user entry, which is a combination of the channel ID where the treatment was
+	 * updated and the user ID of the suspicious user.
+	 */
+	get lowTrustId(): string {
+		return this[rawDataSymbol].data.low_trust_id;
+	}
+
+	/**
+	 * The user ID of the moderator.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].data.updated_by.id;
+	}
+
+	/**
+	 * The name of the moderator.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].data.updated_by.login;
+	}
+
+	/**
+	 * The display name of the moderator.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].data.updated_by.display_name;
+	}
+
+	/**
+	 * The date of when the treatment was updated for the suspicious user.
+	 */
+	get updateDate(): Date {
+		return new Date(this[rawDataSymbol].data.updated_at);
+	}
+
+	/**
+	 * The user ID of the suspicious user
+	 */
+	get targetUserId(): string {
+		return this[rawDataSymbol].data.target_user_id;
+	}
+
+	/**
+	 * The name of the suspicious user.
+	 */
+	get targetUserName(): string {
+		return this[rawDataSymbol].data.target_user;
+	}
+
+	/**
+	 * The treatment set for the suspicious user.
+	 */
+	get treatment(): PubSubLowTrustUserTreatmentType {
+		return this[rawDataSymbol].data.treatment;
+	}
+
+	/**
+	 * User types (if any) that apply to the suspicious user.
+	 */
+	get types(): PubSubLowTrustUserType[] {
+		return this[rawDataSymbol].data.types;
+	}
+
+	/**
+	 * The ban evasion likelihood value that as been applied to the user automatically by Twitch.
+	 *
+	 * Can be an empty string.
+	 */
+	get banEvasionEvaluation(): PubSubLowTrustUserBanEvasionEvaluationType {
+		return this[rawDataSymbol].data.ban_evasion_evaluation;
+	}
+
+	/**
+	 * The date for the first time the suspicious user was automatically evaluated by Twitch.
+	 *
+	 * Will be `null` if {@link PubSubLowTrustUserTreatmentMessage#banEvasionEvaluation} is empty.
+	 */
+	get evaluationDate(): Date | null {
+		// PubSub sends `0001-01-01T00:00:00.000Z` string
+		// if the field is not applicable
+		const date = this[rawDataSymbol].data.evaluated_at
+			? new Date(this[rawDataSymbol].data.evaluated_at)
+			: undefined;
+
+		return date && date.getTime() > 0 ? date : null;
+	}
+}

--- a/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.ts
+++ b/packages/pubsub/src/messages/PubSubLowTrustUserTreatmentMessage.ts
@@ -83,9 +83,9 @@ export class PubSubLowTrustUserTreatmentMessage extends DataObject<PubSubLowTrus
 	}
 
 	/**
-	 * The ban evasion likelihood value that as been applied to the user automatically by Twitch.
+	 * A ban evasion likelihood value that as been applied to the user automatically by Twitch.
 	 *
-	 * Can be an empty string.
+	 * Can be an empty string if Twitch did not apply any evasion value.
 	 */
 	get banEvasionEvaluation(): PubSubLowTrustUserBanEvasionEvaluationType {
 		return this[rawDataSymbol].data.ban_evasion_evaluation;
@@ -97,8 +97,7 @@ export class PubSubLowTrustUserTreatmentMessage extends DataObject<PubSubLowTrus
 	 * Will be `null` if {@link PubSubLowTrustUserTreatmentMessage#banEvasionEvaluation} is empty.
 	 */
 	get evaluationDate(): Date | null {
-		// PubSub sends `0001-01-01T00:00:00.000Z` string
-		// if the field is not applicable
+		// PubSub sends `0001-01-01T00:00:00.000Z` string if the field is not applicable
 		const date = this[rawDataSymbol].data.evaluated_at
 			? new Date(this[rawDataSymbol].data.evaluated_at)
 			: undefined;

--- a/packages/pubsub/src/messages/PubSubMessage.ts
+++ b/packages/pubsub/src/messages/PubSubMessage.ts
@@ -11,6 +11,10 @@ import { type PubSubChannelTermsActionMessageData } from './PubSubChannelTermsAc
 import { type PubSubChatModActionMessage } from './PubSubChatModActionMessage';
 import { type PubSubChatModActionMessageData } from './PubSubChatModActionMessage.external';
 import { type PubSubCustomMessage } from './PubSubCustomMessage';
+import { type PubSubLowTrustUserTreatmentMessage } from './PubSubLowTrustUserTreatmentMessage';
+import { type PubSubLowTrustUserTreatmentMessageData } from './PubSubLowTrustUserTreatmentMessage.external';
+import { type PubSubLowTrustUserChatMessage } from './PubSubLowTrustUserChatMessage';
+import { type PubSubLowTrustUserChatMessageData } from './PubSubLowTrustUserChatMessage.external';
 import { type PubSubRedemptionMessage } from './PubSubRedemptionMessage';
 import { type PubSubRedemptionMessageData } from './PubSubRedemptionMessage.external';
 import { type PubSubSubscriptionMessage } from './PubSubSubscriptionMessage';
@@ -21,6 +25,9 @@ import { type PubSubUserModerationNotificationMessage } from './PubSubUserModera
 import { type PubSubUserModerationNotificationMessageData } from './PubSubUserModerationNotificationMessage.external';
 import { type PubSubWhisperMessage } from './PubSubWhisperMessage';
 import { type PubSubWhisperMessageData } from './PubSubWhisperMessage.external';
+
+/** @private */
+export type PubSubLowTrustUserMessageData = PubSubLowTrustUserTreatmentMessageData | PubSubLowTrustUserChatMessageData;
 
 /** @private */
 export type PubSubModActionMessageData =
@@ -34,12 +41,15 @@ export type PubSubMessageData =
 	| PubSubAutoModQueueMessageData
 	| PubSubBitsMessageData
 	| PubSubBitsBadgeUnlockMessageData
+	| PubSubLowTrustUserMessageData
 	| PubSubModActionMessageData
 	| PubSubRedemptionMessageData
 	| PubSubSubscriptionMessageData
 	| PubSubUserModerationNotificationMessageData
 	| PubSubWhisperMessageData
 	| unknown;
+
+export type PubSubLowTrustUserMessage = PubSubLowTrustUserTreatmentMessage | PubSubLowTrustUserChatMessage;
 
 /** @private */
 export type PubSubModActionMessage =
@@ -53,6 +63,7 @@ export type PubSubMessage =
 	| PubSubAutoModQueueMessage
 	| PubSubBitsMessage
 	| PubSubBitsBadgeUnlockMessage
+	| PubSubLowTrustUserMessage
 	| PubSubModActionMessage
 	| PubSubRedemptionMessage
 	| PubSubSubscriptionMessage

--- a/packages/pubsub/src/messages/common/PubSubLowTrustUserContentBase.external.ts
+++ b/packages/pubsub/src/messages/common/PubSubLowTrustUserContentBase.external.ts
@@ -1,0 +1,39 @@
+/**
+ * The treatment set for the suspicious user.
+ */
+export type PubSubLowTrustUserTreatmentType = 'NO_TREATMENT' | 'ACTIVE_MONITORING' | 'RESTRICTED';
+
+/**
+ * A ban evasion likelihood value (if any) that as been applied to the user automatically by Twitch.
+ */
+export type PubSubLowTrustUserBanEvasionEvaluationType =
+	| 'UNKNOWN_EVADER'
+	| 'UNLIKELY_EVADER'
+	| 'LIKELY_EVADER'
+	| 'POSSIBLE_EVADER'
+	| '';
+
+/**
+ * User types that apply to the suspicious user.
+ */
+export type PubSubLowTrustUserType =
+	| 'UNKNOWN_TYPE'
+	| 'MANUALLY_ADDED'
+	| 'DETECTED_BAN_EVADER'
+	| 'BANNED_IN_SHARED_CHANNEL';
+
+/** @private */
+export interface PubSubLowTrustUserContentBase {
+	low_trust_id: string;
+	channel_id: string;
+	updated_by: {
+		id: string;
+		login: string;
+		display_name: string;
+	};
+	updated_at: string;
+	treatment: PubSubLowTrustUserTreatmentType;
+	types: PubSubLowTrustUserType[];
+	ban_evasion_evaluation: PubSubLowTrustUserBanEvasionEvaluationType;
+	evaluated_at: string;
+}

--- a/packages/pubsub/src/messages/common/PubSubLowTrustUserContentBase.external.ts
+++ b/packages/pubsub/src/messages/common/PubSubLowTrustUserContentBase.external.ts
@@ -14,7 +14,7 @@ export type PubSubLowTrustUserBanEvasionEvaluationType =
 	| '';
 
 /**
- * User types that apply to the suspicious user.
+ * User types (if any) that apply to the suspicious user.
  */
 export type PubSubLowTrustUserType =
 	| 'UNKNOWN_TYPE'


### PR DESCRIPTION
Type: Feature
Fixes: #466 

Tested locally using `yalc`. 

`/monitor` and `/unmonitor` chat commands trigger `PubSubLowTrustUserTreatmentMessage` event, and the chat messages from the monitored user trigger `PubSubLowTrustUserChatMessage` event. Works like a charm. 

### Notes

I want to point your attention to the following things:

1. `userId`, `userName`, and `userDisplayName` members of the `PubSubLowTrustUserTreatmentMessage` and  `PubSubLowTrustUserChatMessage` point to the moderator user, while the target suspicious user is behind `target*` and `sender*` members. Probably it makes sense to change it and make `user*` members point to the target user, and `moderator*` (or `updatedByUser*`) members point to the moderator?
2. Both `PubSubLowTrustUserTreatmentMessage` and  `PubSubLowTrustUserChatMessage` have common types, so I put them into the newly created `common` directory. Let me know if it is wrong.