### PR TITLE
Bugfix for #470 - update parameter order for EBS Helper methods

### DIFF
--- a/packages/ebs-helper/src/helpers.external.ts
+++ b/packages/ebs-helper/src/helpers.external.ts
@@ -56,15 +56,15 @@ export function createConfigurationSegmentBody(
 	config: EbsCallConfig,
 	segment: 'global' | 'broadcaster' | 'developer',
 	broadcaster?: UserIdResolvable,
-	version?: string,
-	content?: string
+	content?: string,
+	version?: string
 ) {
 	return {
 		extension_id: config.clientId,
 		segment,
 		broadcaster_id: mapOptional(broadcaster, extractUserId),
-		version,
-		content
+		content,
+		version
 	};
 }
 

--- a/packages/ebs-helper/src/helpers.ts
+++ b/packages/ebs-helper/src/helpers.ts
@@ -205,8 +205,8 @@ async function setAnyConfigurationSegment(
 	config: EbsCallConfig,
 	segment: HelixExtensionConfigurationSegmentName,
 	broadcaster?: UserIdResolvable,
-	version?: string,
-	content?: string
+	content?: string,
+	version?: string
 ): Promise<void> {
 	const jwt = createExternalJwt(config);
 
@@ -214,7 +214,7 @@ async function setAnyConfigurationSegment(
 		{
 			url: 'extensions/configurations',
 			method: 'PUT',
-			jsonBody: createConfigurationSegmentBody(config, segment, broadcaster, version, content)
+			jsonBody: createConfigurationSegmentBody(config, segment, broadcaster, content, version)
 		},
 		config.clientId,
 		jwt


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Bugfix
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #470 

<!-- Here you can explain in further detail what your pull request contains. -->
Fixed the order of parameters in methods setAnyConfigurationSegment & createConfigurationSegmentBody so calling methods parameters order matches.