### PR TITLE
Make userId in helix moderator filter optional

### DIFF
--- a/packages/api/src/interfaces/helix/moderation.input.ts
+++ b/packages/api/src/interfaces/helix/moderation.input.ts
@@ -23,7 +23,7 @@ export interface HelixModeratorFilter extends HelixForwardPagination {
 	/**
 	 * A user ID or a list thereof.
 	 */
-	userId: string | string[];
+	userId?: string | string[];
 }
 
 export interface HelixCheckAutoModStatusData {


### PR DESCRIPTION
Type: Bugfix
Fixes: #

I noticed, since I wanted to get a list of moderators myself, that the "HelixModeratorFilter" always wants a UserID, even though this is optional from the Twitch Rest API. With this small bugfix it is now possible to get a bigger list than 20 moderators.