### PR TITLE
#486 Make ChatClient#connect and ChatClient#reconnect synchronous 

### DIFF
--- a/packages/chat/src/ChatClient.ts
+++ b/packages/chat/src/ChatClient.ts
@@ -1201,10 +1201,8 @@ export class ChatClient extends EventEmitter {
 
 	/**
 	 * Connects to the chat server.
-	 *
-	 * This method doesn't actually do anything async, so you can ignore the promise it returns.
 	 */
-	async connect(): Promise<void> {
+	connect(): void {
 		if (!this._authProvider) {
 			this._ircClient.changeNick(ChatClient._generateJustinfanNick());
 		}
@@ -1327,12 +1325,10 @@ export class ChatClient extends EventEmitter {
 
 	/**
 	 * Reconnects to the chat server.
-	 *
-	 * This method doesn't actually do anything async, so you can ignore the promise it returns.
 	 */
-	async reconnect(): Promise<void> {
+	reconnect(): void {
 		this.quit();
-		await this.connect();
+		this.connect();
 	}
 
 	private async _getAuthToken(): Promise<string | undefined> {

--- a/packages/easy-bot/src/Bot.ts
+++ b/packages/easy-bot/src/Bot.ts
@@ -566,7 +566,7 @@ export class Bot extends EventEmitter {
 		);
 		// endregion
 
-		void this.chat.connect();
+		this.chat.connect();
 	}
 
 	// region chat management commands


### PR DESCRIPTION
Type: Improvement 

Fixes: #486 

Removed unnecessary async from ChatClient#connect and ChatClient#reconnect methods.