### PR TITLE
Update EventSub WS URL

### DIFF
--- a/packages/eventsub-ws/src/EventSubWsListener.ts
+++ b/packages/eventsub-ws/src/EventSubWsListener.ts
@@ -62,7 +62,7 @@ export class EventSubWsListener extends EventSubBase implements EventSubListener
 	constructor(config: EventSubWsConfig) {
 		super(config);
 
-		this._initialUrl = config.url ?? 'wss://eventsub-beta.wss.twitch.tv/ws';
+		this._initialUrl = config.url ?? 'wss://eventsub.wss.twitch.tv/ws';
 		this._loggerOptions = config.logger;
 	}
 


### PR DESCRIPTION
Type: Improvement

Fixes: #501 

Updated EventSub WS endpoint URL from `wss://eventsub-beta.wss.twitch.tv/ws` to `wss://eventsub.wss.twitch.tv/ws`

Twitch announcement: https://discuss.dev.twitch.tv/t/update-required-for-eventsub-websockets-beta-connection-url/45079