### PR TITLE
fix getStreamKey "no context user ID" error

### DIFF
--- a/packages/api/src/endpoints/stream/HelixStreamApi.ts
+++ b/packages/api/src/endpoints/stream/HelixStreamApi.ts
@@ -311,9 +311,11 @@ export class HelixStreamApi extends BaseApi {
 	 * @param broadcaster The broadcaster to get the stream key for.
 	 */
 	async getStreamKey(broadcaster: UserIdResolvable): Promise<string> {
+		const userId = extractUserId(broadcaster);
 		const result = await this._client.callApi<HelixResponse<HelixGetStreamKeyData>>({
 			type: 'helix',
 			url: 'streams/key',
+			userId,
 			scopes: ['channel:read:stream_key'],
 			query: createBroadcasterQuery(broadcaster)
 		});


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Bugfix
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->

When calling the `streams.getStreamKey` endpoint in the `api` package the following error is always displayed, no matter how the client is authed:

```
Error: Tried to make an API call with a scope but no context user ID
```

From my best understanding, this is because the `apiCall` options don't include the userId. Please correct me if I'm wrong here as I'm only just starting to dig into this package :)

**This PR adds the missing userId to the `apiCall` options and fixes the issue**