### PR TITLE
Ad break endpoints

### DIFF
--- a/packages/api/src/endpoints/channel/HelixAdSchedule.ts
+++ b/packages/api/src/endpoints/channel/HelixAdSchedule.ts
@@ -19,14 +19,14 @@ export class HelixAdSchedule extends DataObject<HelixAdScheduleData> {
 	/**
 	 * The date and time when the broadcaster will gain an additional snooze.
 	 */
-	get snoozeRefreshAt(): Date {
+	get snoozeRefreshDate(): Date {
 		return new Date(this[rawDataSymbol].snooze_refresh_at * 1000);
 	}
 
 	/**
 	 * The date and time of the broadcaster's next scheduled ad.
 	 */
-	get nextAdAt(): Date {
+	get nextAdDate(): Date {
 		return new Date(this[rawDataSymbol].next_ad_at * 1000);
 	}
 
@@ -40,7 +40,7 @@ export class HelixAdSchedule extends DataObject<HelixAdScheduleData> {
 	/**
 	 * The date and time of the broadcaster's last ad-break.
 	 */
-	get lastAdAt(): Date {
+	get lastAdDate(): Date {
 		return new Date(this[rawDataSymbol].last_ad_at * 1000);
 	}
 

--- a/packages/api/src/endpoints/channel/HelixAdSchedule.ts
+++ b/packages/api/src/endpoints/channel/HelixAdSchedule.ts
@@ -17,17 +17,17 @@ export class HelixAdSchedule extends DataObject<HelixAdScheduleData> {
 	}
 
 	/**
-	 * The UTC Unix Epoch timestamp when the broadcaster will gain an additional snooze.
+	 * The date and time when the broadcaster will gain an additional snooze.
 	 */
-	get snoozeRefreshAt(): number {
-		return this[rawDataSymbol].snooze_refresh_at;
+	get snoozeRefreshAt(): Date {
+		return new Date(this[rawDataSymbol].snooze_refresh_at * 1000);
 	}
 
 	/**
-	 * The UTC Unix Epoch timestamp of the broadcaster's next scheduled ad.
+	 * The date and time of the broadcaster's next scheduled ad.
 	 */
-	get nextAdAt(): number {
-		return this[rawDataSymbol].next_ad_at;
+	get nextAdAt(): Date {
+		return new Date(this[rawDataSymbol].next_ad_at * 1000);
 	}
 
 	/**
@@ -38,10 +38,10 @@ export class HelixAdSchedule extends DataObject<HelixAdScheduleData> {
 	}
 
 	/**
-	 * The UTC Unix Epoch timestamp of the broadcaster's last ad-break.
+	 * The date and time of the broadcaster's last ad-break.
 	 */
-	get lastAdAt(): number {
-		return this[rawDataSymbol].last_ad_at;
+	get lastAdAt(): Date {
+		return new Date(this[rawDataSymbol].last_ad_at * 1000);
 	}
 
 	/**

--- a/packages/api/src/endpoints/channel/HelixAdSchedule.ts
+++ b/packages/api/src/endpoints/channel/HelixAdSchedule.ts
@@ -1,0 +1,53 @@
+// import { Enumerable } from '@d-fischer/shared-utils';
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+// import type { BaseApiClient } from '../../client/BaseApiClient';
+import type { HelixAdScheduleData } from '../../interfaces/endpoints/channel.external';
+// import type { HelixUser } from '../user/HelixUser';
+
+/**
+ * Represents a broadcaster's ad schedule.
+ */
+@rtfm('api', 'HelixAdSchedule')
+export class HelixAdSchedule extends DataObject<HelixAdScheduleData> {
+	/**
+	 * The number of snoozes available for the broadcaster.
+	 */
+	get snoozeCount(): number {
+		return this[rawDataSymbol].snooze_count;
+	}
+
+	/**
+	 * The UTC Unix Epoch timestamp when the broadcaster will gain an additional snooze.
+	 */
+	get snoozeRefreshAt(): number {
+		return this[rawDataSymbol].snooze_refresh_at;
+	}
+
+	/**
+	 * The UTC Unix Epoch timestamp of the broadcaster's next scheduled ad.
+	 */
+	get nextAdAt(): number {
+		return this[rawDataSymbol].next_ad_at;
+	}
+
+	/**
+	 * The length in seconds of the scheduled upcoming ad break.
+	 */
+	get duration(): number {
+		return this[rawDataSymbol].duration;
+	}
+
+	/**
+	 * The UTC Unix Epoch timestamp of the broadcaster's last ad-break.
+	 */
+	get lastAdAt(): number {
+		return this[rawDataSymbol].last_ad_at;
+	}
+
+	/**
+	 * The amount of pre-roll free time remaining for the channel in seconds.
+	 */
+	get prerollFreeTime(): number {
+		return this[rawDataSymbol].preroll_free_time;
+	}
+}

--- a/packages/api/src/endpoints/channel/HelixChannelApi.ts
+++ b/packages/api/src/endpoints/channel/HelixChannelApi.ts
@@ -16,6 +16,7 @@ import {
 	type HelixChannelEditorData,
 	type HelixChannelFollowerData,
 	type HelixFollowedChannelData,
+	type HelixAdScheduleData,
 } from '../../interfaces/endpoints/channel.external';
 import { type HelixChannelUpdate } from '../../interfaces/endpoints/channel.input';
 import {
@@ -39,6 +40,7 @@ import { HelixChannel } from './HelixChannel';
 import { HelixChannelEditor } from './HelixChannelEditor';
 import { HelixChannelFollower } from './HelixChannelFollower';
 import { HelixFollowedChannel } from './HelixFollowedChannel';
+import { HelixAdSchedule } from './HelixAdSchedule';
 
 /**
  * The Helix API methods that deal with channels.
@@ -412,5 +414,23 @@ export class HelixChannelApi extends BaseApi {
 			this._client,
 			data => new HelixFollowedChannel(data, this._client),
 		);
+	}
+
+	/**
+	 * Gets information about the broadcaster's ad schedule.
+	 *
+	 * @param broadcaster The broadcaster to get ad schedule information about.
+	 */
+	async getAdSchedule(broadcaster: UserIdResolvable): Promise<HelixAdSchedule> {
+		const response = await this._client.callApi<HelixResponse<HelixAdScheduleData>>({
+			type: 'helix',
+			url: 'channels/ads',
+			method: 'GET',
+			userId: extractUserId(broadcaster),
+			scopes: ['channel:read:ads'],
+			query: createBroadcasterQuery(broadcaster),
+		});
+
+		return new HelixAdSchedule(response.data[0]);
 	}
 }

--- a/packages/api/src/endpoints/channel/HelixChannelApi.ts
+++ b/packages/api/src/endpoints/channel/HelixChannelApi.ts
@@ -42,7 +42,7 @@ import { HelixChannelEditor } from './HelixChannelEditor';
 import { HelixChannelFollower } from './HelixChannelFollower';
 import { HelixFollowedChannel } from './HelixFollowedChannel';
 import { HelixAdSchedule } from './HelixAdSchedule';
-import { HelixSnoozeNextAdResult } from './HelixSnoozeNextAd';
+import { HelixSnoozeNextAdResult } from './HelixSnoozeNextAdResult';
 
 /**
  * The Helix API methods that deal with channels.

--- a/packages/api/src/endpoints/channel/HelixChannelApi.ts
+++ b/packages/api/src/endpoints/channel/HelixChannelApi.ts
@@ -17,6 +17,7 @@ import {
 	type HelixChannelFollowerData,
 	type HelixFollowedChannelData,
 	type HelixAdScheduleData,
+	type HelixSnoozeNextAdData,
 } from '../../interfaces/endpoints/channel.external';
 import { type HelixChannelUpdate } from '../../interfaces/endpoints/channel.input';
 import {
@@ -41,6 +42,7 @@ import { HelixChannelEditor } from './HelixChannelEditor';
 import { HelixChannelFollower } from './HelixChannelFollower';
 import { HelixFollowedChannel } from './HelixFollowedChannel';
 import { HelixAdSchedule } from './HelixAdSchedule';
+import { HelixSnoozeNextAd } from './HelixSnoozeNextAd';
 
 /**
  * The Helix API methods that deal with channels.
@@ -432,5 +434,23 @@ export class HelixChannelApi extends BaseApi {
 		});
 
 		return new HelixAdSchedule(response.data[0]);
+	}
+
+	/**
+	 * Snoozes the broadcaster's next ad, if a snooze is available.
+	 *
+	 * @param broadcaster The broadcaster to get ad schedule information about.
+	 */
+	async snoozeNextAd(broadcaster: UserIdResolvable): Promise<HelixSnoozeNextAd> {
+		const response = await this._client.callApi<HelixResponse<HelixSnoozeNextAdData>>({
+			type: 'helix',
+			url: 'channels/ads/schedule/snooze',
+			method: 'POST',
+			userId: extractUserId(broadcaster),
+			scopes: ['channel:manage:ads'],
+			query: createBroadcasterQuery(broadcaster),
+		});
+
+		return new HelixSnoozeNextAd(response.data[0]);
 	}
 }

--- a/packages/api/src/endpoints/channel/HelixChannelApi.ts
+++ b/packages/api/src/endpoints/channel/HelixChannelApi.ts
@@ -42,7 +42,7 @@ import { HelixChannelEditor } from './HelixChannelEditor';
 import { HelixChannelFollower } from './HelixChannelFollower';
 import { HelixFollowedChannel } from './HelixFollowedChannel';
 import { HelixAdSchedule } from './HelixAdSchedule';
-import { HelixSnoozeNextAd } from './HelixSnoozeNextAd';
+import { HelixSnoozeNextAdResult } from './HelixSnoozeNextAd';
 
 /**
  * The Helix API methods that deal with channels.
@@ -441,7 +441,7 @@ export class HelixChannelApi extends BaseApi {
 	 *
 	 * @param broadcaster The broadcaster to get ad schedule information about.
 	 */
-	async snoozeNextAd(broadcaster: UserIdResolvable): Promise<HelixSnoozeNextAd> {
+	async snoozeNextAd(broadcaster: UserIdResolvable): Promise<HelixSnoozeNextAdResult> {
 		const response = await this._client.callApi<HelixResponse<HelixSnoozeNextAdData>>({
 			type: 'helix',
 			url: 'channels/ads/schedule/snooze',
@@ -451,6 +451,6 @@ export class HelixChannelApi extends BaseApi {
 			query: createBroadcasterQuery(broadcaster),
 		});
 
-		return new HelixSnoozeNextAd(response.data[0]);
+		return new HelixSnoozeNextAdResult(response.data[0]);
 	}
 }

--- a/packages/api/src/endpoints/channel/HelixSnoozeNextAd.ts
+++ b/packages/api/src/endpoints/channel/HelixSnoozeNextAd.ts
@@ -1,0 +1,32 @@
+// import { Enumerable } from '@d-fischer/shared-utils';
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+// import type { BaseApiClient } from '../../client/BaseApiClient';
+import type { HelixSnoozeNextAdData } from '../../interfaces/endpoints/channel.external';
+// import type { HelixUser } from '../user/HelixUser';
+
+/**
+ * Represents a broadcaster's ad schedule snooze event.
+ */
+@rtfm('api', 'HelixSnoozeNextAd')
+export class HelixSnoozeNextAd extends DataObject<HelixSnoozeNextAdData> {
+	/**
+	 * The number of snoozes remaining for the broadcaster.
+	 */
+	get snoozeCount(): number {
+		return this[rawDataSymbol].snooze_count;
+	}
+
+	/**
+	 * The UTC Unix Epoch timestamp when the broadcaster will gain an additional snooze.
+	 */
+	get snoozeRefreshAt(): number {
+		return this[rawDataSymbol].snooze_refresh_at;
+	}
+
+	/**
+	 * The UTC Unix Epoch timestamp of the broadcaster's next scheduled ad.
+	 */
+	get nextAdAt(): number {
+		return this[rawDataSymbol].next_ad_at;
+	}
+}

--- a/packages/api/src/endpoints/channel/HelixSnoozeNextAd.ts
+++ b/packages/api/src/endpoints/channel/HelixSnoozeNextAd.ts
@@ -1,14 +1,11 @@
-// import { Enumerable } from '@d-fischer/shared-utils';
 import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
-// import type { BaseApiClient } from '../../client/BaseApiClient';
 import type { HelixSnoozeNextAdData } from '../../interfaces/endpoints/channel.external';
-// import type { HelixUser } from '../user/HelixUser';
 
 /**
- * Represents a broadcaster's ad schedule snooze event.
+ * Represents the result after a call to snooze the broadcaster's ad schedule.
  */
-@rtfm('api', 'HelixSnoozeNextAd')
-export class HelixSnoozeNextAd extends DataObject<HelixSnoozeNextAdData> {
+@rtfm('api', 'HelixSnoozeNextAdResult')
+export class HelixSnoozeNextAdResult extends DataObject<HelixSnoozeNextAdData> {
 	/**
 	 * The number of snoozes remaining for the broadcaster.
 	 */
@@ -17,16 +14,16 @@ export class HelixSnoozeNextAd extends DataObject<HelixSnoozeNextAdData> {
 	}
 
 	/**
-	 * The UTC Unix Epoch timestamp when the broadcaster will gain an additional snooze.
+	 * The date and time when the broadcaster will gain an additional snooze.
 	 */
-	get snoozeRefreshAt(): number {
-		return this[rawDataSymbol].snooze_refresh_at;
+	get snoozeRefreshAt(): Date {
+		return new Date(this[rawDataSymbol].snooze_refresh_at * 1000);
 	}
 
 	/**
-	 * The UTC Unix Epoch timestamp of the broadcaster's next scheduled ad.
+	 * The date and time of the broadcaster's next scheduled ad.
 	 */
-	get nextAdAt(): number {
-		return this[rawDataSymbol].next_ad_at;
+	get nextAdAt(): Date {
+		return new Date(this[rawDataSymbol].next_ad_at * 1000);
 	}
 }

--- a/packages/api/src/endpoints/channel/HelixSnoozeNextAdResult.ts
+++ b/packages/api/src/endpoints/channel/HelixSnoozeNextAdResult.ts
@@ -16,14 +16,14 @@ export class HelixSnoozeNextAdResult extends DataObject<HelixSnoozeNextAdData> {
 	/**
 	 * The date and time when the broadcaster will gain an additional snooze.
 	 */
-	get snoozeRefreshAt(): Date {
+	get snoozeRefreshDate(): Date {
 		return new Date(this[rawDataSymbol].snooze_refresh_at * 1000);
 	}
 
 	/**
 	 * The date and time of the broadcaster's next scheduled ad.
 	 */
-	get nextAdAt(): Date {
+	get nextAdDate(): Date {
 		return new Date(this[rawDataSymbol].next_ad_at * 1000);
 	}
 }

--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -1190,9 +1190,9 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
-	 * Subscribe to events that represent an Ad Break beginning in a channel.
+	 * Subscribe to events that represent an ad break beginning in a channel.
 	 *
-	 * @param broadcaster The broadcaster for which you want to listen to Ad Break begin events.
+	 * @param broadcaster The broadcaster for which you want to listen to ad break begin events.
 	 * @param transport The transport options.
 	 */
 	async subscribeToChannelAdBreakBeginEvents(

--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -1190,6 +1190,26 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribe to events that represent an Ad Break beginning in a channel.
+	 *
+	 * @param broadcaster The broadcaster for which you want to listen to Ad Break begin events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelAdBreakBeginEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		return await this.createSubscription(
+			'channel.ad_break.begin',
+			'1',
+			createEventSubBroadcasterCondition(broadcaster),
+			transport,
+			broadcaster,
+			['channel:read:ads'],
+		);
+	}
+
+	/**
 	 * Subscribe to events that represent an extension Bits transaction.
 	 *
 	 * @param clientId The Client ID for the extension you want to listen to Bits transactions for.

--- a/packages/api/src/interfaces/endpoints/channel.external.ts
+++ b/packages/api/src/interfaces/endpoints/channel.external.ts
@@ -49,6 +49,16 @@ export interface HelixChannelFollowerData {
 	followed_at: string;
 }
 
+/** @private */
+export interface HelixAdScheduleData {
+	snooze_count: number;
+	snooze_refresh_at: number;
+	next_ad_at: number;
+	duration: number;
+	last_ad_at: number;
+	preroll_free_time: number;
+}
+
 /** @internal */
 export function createChannelUpdateBody(data: HelixChannelUpdate) {
 	return {

--- a/packages/api/src/interfaces/endpoints/channel.external.ts
+++ b/packages/api/src/interfaces/endpoints/channel.external.ts
@@ -59,6 +59,13 @@ export interface HelixAdScheduleData {
 	preroll_free_time: number;
 }
 
+/** @private */
+export interface HelixSnoozeNextAdData {
+	snooze_count: number;
+	snooze_refresh_at: number;
+	next_ad_at: number;
+}
+
 /** @internal */
 export function createChannelUpdateBody(data: HelixChannelUpdate) {
 	return {

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -10,6 +10,7 @@ import {
 	type UserIdResolvable,
 } from '@twurple/api';
 import { rtfm } from '@twurple/common';
+import type { EventSubChannelAdBreakBeginEvent } from './events/EventSubChannelAdBreakBeginEvent';
 import type { EventSubChannelBanEvent } from './events/EventSubChannelBanEvent';
 import type { EventSubChannelCharityCampaignProgressEvent } from './events/EventSubChannelCharityCampaignProgressEvent';
 import type { EventSubChannelCharityCampaignStartEvent } from './events/EventSubChannelCharityCampaignStartEvent';
@@ -52,6 +53,7 @@ import type { EventSubStreamOnlineEvent } from './events/EventSubStreamOnlineEve
 import type { EventSubUserAuthorizationGrantEvent } from './events/EventSubUserAuthorizationGrantEvent';
 import type { EventSubUserAuthorizationRevokeEvent } from './events/EventSubUserAuthorizationRevokeEvent';
 import type { EventSubUserUpdateEvent } from './events/EventSubUserUpdateEvent';
+import { EventSubChannelAdBreakBeginSubscription } from './subscriptions/EventSubChannelAdBreakBeginSubscription';
 import { EventSubChannelBanSubscription } from './subscriptions/EventSubChannelBanSubscription';
 import { EventSubChannelCharityCampaignProgressSubscription } from './subscriptions/EventSubChannelCharityCampaignProgressSubscription';
 import { EventSubChannelCharityCampaignStartSubscription } from './subscriptions/EventSubChannelCharityCampaignStartSubscription';
@@ -941,6 +943,22 @@ export abstract class EventSubBase extends EventEmitter {
 			moderatorId,
 		);
 	}
+
+	/**
+	 * Subscribes to events that represent an Ad Break beginning.
+	 *
+	 * @param user The user for which to get notifications about Ad Breaks in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelAdBreakBegin(
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelAdBreakBeginEvent) => void,
+	): EventSubSubscription {
+		const userId = this._extractUserIdWithNumericWarning(user, 'subscribeToChannelAdBreakBeginEvents');
+
+		return this._genericSubscribe(EventSubChannelAdBreakBeginSubscription, handler, this, userId);
+	}
+
 	/**
 	 * Subscribes to events that represent a drop entitlement being granted.
 	 *

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -945,9 +945,9 @@ export abstract class EventSubBase extends EventEmitter {
 	}
 
 	/**
-	 * Subscribes to events that represent an Ad Break beginning.
+	 * Subscribes to events that represent an ad break beginning.
 	 *
-	 * @param user The user for which to get notifications about Ad Breaks in their channel.
+	 * @param user The user for which to get notifications about ad breaks in their channel.
 	 * @param handler The function that will be called for any new notifications.
 	 */
 	onChannelAdBreakBegin(

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -1,5 +1,6 @@
 import { type HelixEventSubDropEntitlementGrantFilter } from '@twurple/api';
 import type { UserIdResolvable } from '@twurple/common';
+import type { EventSubChannelAdBreakBeginEvent } from './events/EventSubChannelAdBreakBeginEvent';
 import type { EventSubChannelBanEvent } from './events/EventSubChannelBanEvent';
 import type { EventSubChannelCharityCampaignProgressEvent } from './events/EventSubChannelCharityCampaignProgressEvent';
 import type { EventSubChannelCharityCampaignStartEvent } from './events/EventSubChannelCharityCampaignStartEvent';
@@ -566,6 +567,17 @@ export interface EventSubListener {
 		broadcaster: UserIdResolvable,
 		moderator: UserIdResolvable,
 		handler: (data: EventSubChannelShoutoutReceiveEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent an Ad Break beginning in a channel.
+	 *
+	 * @param user The user for which to get notifications about Hype Trains in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelAdBreakBegin: (
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelAdBreakBeginEvent) => void,
 	) => EventSubSubscription;
 
 	/**

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -570,7 +570,7 @@ export interface EventSubListener {
 	) => EventSubSubscription;
 
 	/**
-	 * Subscribes to events that represent an Ad Break beginning in a channel.
+	 * Subscribes to events that represent an ad break beginning in a channel.
 	 *
 	 * @param user The user for which to get notifications about Hype Trains in their channel.
 	 * @param handler The function that will be called for any new notifications.

--- a/packages/eventsub-base/src/events/EventSubChannelAdBreakBeginEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelAdBreakBeginEvent.external.ts
@@ -1,0 +1,12 @@
+/** @private */
+export interface EventSubChannelAdBreakBeginEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	requester_user_id: string;
+	requester_user_login: string;
+	requester_user_name: string;
+	started_at: string;
+	duration_seconds: number;
+	is_automatic: boolean;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelAdBreakBeginEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelAdBreakBeginEvent.ts
@@ -87,7 +87,7 @@ export class EventSubChannelAdBreakBeginEvent extends DataObject<EventSubChannel
 	}
 
 	/**
-	 * Indicates if the ad was automatically scheduled via Ads Manager
+	 * Indicates if the ad was automatically scheduled via Ads Manager.
 	 */
 	get isAutomatic(): boolean {
 		return this[rawDataSymbol].is_automatic;

--- a/packages/eventsub-base/src/events/EventSubChannelAdBreakBeginEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelAdBreakBeginEvent.ts
@@ -1,0 +1,95 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubChannelAdBreakBeginEventData } from './EventSubChannelAdBreakBeginEvent.external';
+
+/**
+ * An EventSub event representing an ad break beginning in a broadcaster channel.
+ */
+@rtfm<EventSubChannelAdBreakBeginEvent>('eventsub-base', 'EventSubChannelAdBreakBeginEvent', 'broadcasterId')
+export class EventSubChannelAdBreakBeginEvent extends DataObject<EventSubChannelAdBreakBeginEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelAdBreakBeginEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The broadcaster's user ID for the channel the ad was run on.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The broadcaster's user login for the channel the ad was run on.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The broadcaster's user display name for the channel the ad was run on.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the user that requested the ad. For automatic ads, this will be the ID of the broadcaster.
+	 */
+	get requesterId(): string {
+		return this[rawDataSymbol].requester_user_id;
+	}
+
+	/**
+	 * The login of the user that requested the ad.
+	 */
+	get requesterName(): string {
+		return this[rawDataSymbol].requester_user_login;
+	}
+
+	/**
+	 * The display name of the user that requested the ad.
+	 */
+	get requesterDisplayName(): string {
+		return this[rawDataSymbol].requester_user_name;
+	}
+
+	/**
+	 * Gets more information about the user that requested the ad.
+	 */
+	async getRequester(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].requester_user_id));
+	}
+
+	/**
+	 * Length in seconds of the mid-roll ad break requested.
+	 */
+	get durationSeconds(): number {
+		return this[rawDataSymbol].duration_seconds;
+	}
+
+	/**
+	 * The date/time when the ad break started.
+	 */
+	get startDate(): Date {
+		return new Date(this[rawDataSymbol].started_at);
+	}
+
+	/**
+	 * Indicates if the ad was automatically scheduled via Ads Manager
+	 */
+	get isAutomatic(): boolean {
+		return this[rawDataSymbol].is_automatic;
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelAdBreakBeginSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelAdBreakBeginSubscription.ts
@@ -1,0 +1,39 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import { EventSubChannelAdBreakBeginEvent } from '../events/EventSubChannelAdBreakBeginEvent';
+import { type EventSubChannelAdBreakBeginEventData } from '../events/EventSubChannelAdBreakBeginEvent.external';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelAdBreakBeginSubscription extends EventSubSubscription<EventSubChannelAdBreakBeginEvent> {
+	/** @protected */ readonly _cliName = 'ad-break-begin';
+
+	constructor(
+		handler: (data: EventSubChannelAdBreakBeginEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.ad_break.begin.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(data: EventSubChannelAdBreakBeginEventData): EventSubChannelAdBreakBeginEvent {
+		return new EventSubChannelAdBreakBeginEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelAdBreakBeginEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Feature
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
Alternatively, if the issue this fixes was only discussed on Discord, please state that here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE OR TALKING TO US ABOUT IT ON DISCORD: https://discord.gg/b9ZqMfz
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #532 

Twitch moved these to GA.

https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelad_breakbegin
https://dev.twitch.tv/docs/api/reference/#get-ad-schedule
https://dev.twitch.tv/docs/api/reference/#snooze-next-ad

The timestamps are a bit different since they're using unix epoch timestamps, rather than the traditional strings as every other API endpoint. [Apparently that's expected?](https://github.com/twitchdev/issues/issues/879#issuecomment-1858380731)
