### PR TITLE
add ChatClear, ChatClearUserMessages, ChatMessageDelete events

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/twitch-ext": "^1.24.4",
     "cross-env": "^7.0.3",
     "crowd": "^0.1.7",
-    "eslint": "^8.12.0",
+    "eslint": "8.50.0",
     "husky": "^4.3.6",
     "jest": "^29.5.0",
     "jest-environment-node": "^29.5.0",

--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -1210,6 +1210,66 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribe to events that represent a channel's chat being cleared.
+	 *
+	 * @param broadcaster The broadcaster for which you want to listen to chat clear events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelChatClearEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		return await this.createSubscription(
+			'channel.chat.clear',
+			'1',
+			createEventSubBroadcasterCondition(broadcaster),
+			transport,
+			broadcaster,
+			['user:read:chat'],
+		);
+	}
+
+	/**
+	 * Subscribe to events that represent a user's chat messages being cleared in a channel.
+	 *
+	 * @param broadcaster The broadcaster for which you want to listen to user chat message clear events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelChatClearUserMessagesEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		return await this.createSubscription(
+			'channel.chat.clear_user_messages',
+			'1',
+			createEventSubBroadcasterCondition(broadcaster),
+			transport,
+			broadcaster,
+			['user:read:chat'],
+		);
+	}
+
+	/**
+	 * Subscribe to events that represent a chat message being deleted in a channel.
+	 *
+	 * @param broadcaster The broadcaster for which you want to listen to chat message delete events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelChatMessageDeleteEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		return await this.createSubscription(
+			'channel.chat.message_delete',
+			'1',
+			createEventSubBroadcasterCondition(broadcaster),
+			transport,
+			broadcaster,
+			['user:read:chat'],
+		);
+	}
+
+	/**
 	 * Subscribe to events that represent an extension Bits transaction.
 	 *
 	 * @param clientId The Client ID for the extension you want to listen to Bits transactions for.

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -16,6 +16,9 @@ import type { EventSubChannelCharityCampaignProgressEvent } from './events/Event
 import type { EventSubChannelCharityCampaignStartEvent } from './events/EventSubChannelCharityCampaignStartEvent';
 import type { EventSubChannelCharityCampaignStopEvent } from './events/EventSubChannelCharityCampaignStopEvent';
 import type { EventSubChannelCharityDonationEvent } from './events/EventSubChannelCharityDonationEvent';
+import type { EventSubChannelChatClearEvent } from './events/EventSubChannelChatClearEvent';
+import type { EventSubChannelChatClearUserMessagesEvent } from './events/EventSubChannelChatClearUserMessagesEvent';
+import type { EventSubChannelChatMessageDeleteEvent } from './events/EventSubChannelChatMessageDeleteEvent';
 import type { EventSubChannelCheerEvent } from './events/EventSubChannelCheerEvent';
 import type { EventSubChannelFollowEvent } from './events/EventSubChannelFollowEvent';
 import type { EventSubChannelGoalBeginEvent } from './events/EventSubChannelGoalBeginEvent';
@@ -59,6 +62,9 @@ import { EventSubChannelCharityCampaignProgressSubscription } from './subscripti
 import { EventSubChannelCharityCampaignStartSubscription } from './subscriptions/EventSubChannelCharityCampaignStartSubscription';
 import { EventSubChannelCharityCampaignStopSubscription } from './subscriptions/EventSubChannelCharityCampaignStopSubscription';
 import { EventSubChannelCharityDonationSubscription } from './subscriptions/EventSubChannelCharityDonationSubscription';
+import { EventSubChannelChatClearSubscription } from './subscriptions/EventSubChannelChatClearSubscription';
+import { EventSubChannelChatClearUserMessagesSubscription } from './subscriptions/EventSubChannelChatClearUserMessagesSubscription';
+import { EventSubChannelChatMessageDeleteSubscription } from './subscriptions/EventSubChannelChatMessageDeleteSubscription';
 import { EventSubChannelCheerSubscription } from './subscriptions/EventSubChannelCheerSubscription';
 import { EventSubChannelFollowSubscription } from './subscriptions/EventSubChannelFollowSubscription';
 import { EventSubChannelGoalBeginSubscription } from './subscriptions/EventSubChannelGoalBeginSubscription';
@@ -957,6 +963,51 @@ export abstract class EventSubBase extends EventEmitter {
 		const userId = this._extractUserIdWithNumericWarning(user, 'subscribeToChannelAdBreakBeginEvents');
 
 		return this._genericSubscribe(EventSubChannelAdBreakBeginSubscription, handler, this, userId);
+	}
+
+	/**
+	 * Subscribes to events that represent an channel's chat being cleared.
+	 *
+	 * @param user The user for which to get notifications about chat being cleared in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatClear(
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatClearEvent) => void,
+	): EventSubSubscription {
+		const userId = this._extractUserIdWithNumericWarning(user, 'subscribeToChannelChatClearEvents');
+
+		return this._genericSubscribe(EventSubChannelChatClearSubscription, handler, this, userId);
+	}
+
+	/**
+	 * Subscribes to events that represent a user's chat messages being cleared in a channel.
+	 *
+	 * @param user The user for which to get notifications about a user's chat messages being cleared in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatClearUserMessages(
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatClearUserMessagesEvent) => void,
+	): EventSubSubscription {
+		const userId = this._extractUserIdWithNumericWarning(user, 'subscribeToChannelChatClearUserMessagesEvents');
+
+		return this._genericSubscribe(EventSubChannelChatClearUserMessagesSubscription, handler, this, userId);
+	}
+
+	/**
+	 * Subscribes to events that represent a chat message being deleted in a channel.
+	 *
+	 * @param user The user for which to get notifications about a chat message being deleted in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatMessageDelete(
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatMessageDeleteEvent) => void,
+	): EventSubSubscription {
+		const userId = this._extractUserIdWithNumericWarning(user, 'subscribeToChannelChatMessageDeleteEvents');
+
+		return this._genericSubscribe(EventSubChannelChatMessageDeleteSubscription, handler, this, userId);
 	}
 
 	/**

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -6,6 +6,9 @@ import type { EventSubChannelCharityCampaignProgressEvent } from './events/Event
 import type { EventSubChannelCharityCampaignStartEvent } from './events/EventSubChannelCharityCampaignStartEvent';
 import type { EventSubChannelCharityCampaignStopEvent } from './events/EventSubChannelCharityCampaignStopEvent';
 import type { EventSubChannelCharityDonationEvent } from './events/EventSubChannelCharityDonationEvent';
+import type { EventSubChannelChatClearEvent } from './events/EventSubChannelChatClearEvent';
+import type { EventSubChannelChatClearUserMessagesEvent } from './events/EventSubChannelChatClearUserMessagesEvent';
+import type { EventSubChannelChatMessageDeleteEvent } from './events/EventSubChannelChatMessageDeleteEvent';
 import type { EventSubChannelCheerEvent } from './events/EventSubChannelCheerEvent';
 import type { EventSubChannelFollowEvent } from './events/EventSubChannelFollowEvent';
 import type { EventSubChannelGoalBeginEvent } from './events/EventSubChannelGoalBeginEvent';
@@ -578,6 +581,39 @@ export interface EventSubListener {
 	onChannelAdBreakBegin: (
 		user: UserIdResolvable,
 		handler: (data: EventSubChannelAdBreakBeginEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a channel's chat being cleared.
+	 *
+	 * @param user The user for which to get notifications about chat being cleared in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatClear: (
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatClearEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a user's chat messages being cleared in a channel.
+	 *
+	 * @param user The user for which to get notifications about a user's chat messages being cleared in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatClearUserMessages: (
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatClearUserMessagesEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a chat message being deleted in a channel.
+	 *
+	 * @param user The user for which to get notifications about a chat message being deleted in their channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatMessageDelete: (
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatMessageDeleteEvent) => void,
 	) => EventSubSubscription;
 
 	/**

--- a/packages/eventsub-base/src/events/EventSubChannelChatClearEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatClearEvent.external.ts
@@ -1,0 +1,6 @@
+/** @private */
+export interface EventSubChannelChatClearEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatClearEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatClearEvent.ts
@@ -1,0 +1,46 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubChannelChatClearEventData } from './EventSubChannelChatClearEvent.external';
+
+/**
+ * An EventSub event representing a channel's chat being cleared.
+ */
+@rtfm<EventSubChannelChatClearEvent>('eventsub-base', 'EventSubChannelChatClearEvent', 'broadcasterId')
+export class EventSubChannelChatClearEvent extends DataObject<EventSubChannelChatClearEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelChatClearEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatClearUserMessagesEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatClearUserMessagesEvent.external.ts
@@ -1,0 +1,9 @@
+/** @private */
+export interface EventSubChannelChatClearUserMessagesEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	target_user_id: string;
+	target_user_login: string;
+	target_user_name: string;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatClearUserMessagesEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatClearUserMessagesEvent.ts
@@ -1,0 +1,78 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubChannelChatClearUserMessagesEventData } from './EventSubChannelChatClearUserMessagesEvent.external';
+
+/**
+ * An EventSub event representing a user's chat messages being cleared in a channel.
+ */
+@rtfm<EventSubChannelChatClearUserMessagesEvent>(
+	'eventsub-base',
+	'EventSubChannelChatClearUserMessagesEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatClearUserMessagesEvent extends DataObject<EventSubChannelChatClearUserMessagesEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelChatClearUserMessagesEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the user whose chat messages were cleared.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].target_user_id;
+	}
+
+	/**
+	 * The name of the user whose chat messages were cleared.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].target_user_login;
+	}
+
+	/**
+	 * The display name of the user whose chat messages were cleared.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].target_user_name;
+	}
+
+	/**
+	 * Gets more information about the user whose chat messages were cleared.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].target_user_id));
+	}
+
+	/**
+	 * The ID of the broadcaster.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatMessageDeleteEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatMessageDeleteEvent.external.ts
@@ -1,0 +1,10 @@
+/** @private */
+export interface EventSubChannelChatMessageDeleteEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	target_user_id: string;
+	target_user_login: string;
+	target_user_name: string;
+	message_id: string;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatMessageDeleteEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatMessageDeleteEvent.ts
@@ -1,0 +1,81 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubChannelChatMessageDeleteEventData } from './EventSubChannelChatMessageDeleteEvent.external';
+
+/**
+ * An EventSub event representing a chat message being deleted in a channel.
+ */
+@rtfm<EventSubChannelChatMessageDeleteEvent>('eventsub-base', 'EventSubChannelChatMessageDeleteEvent', 'broadcasterId')
+export class EventSubChannelChatMessageDeleteEvent extends DataObject<EventSubChannelChatMessageDeleteEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelChatMessageDeleteEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the user whose chat message was deleted.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].target_user_id;
+	}
+
+	/**
+	 * The name of the user whose chat message was deleted.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].target_user_login;
+	}
+
+	/**
+	 * The display name of the user whose chat message was deleted.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].target_user_name;
+	}
+
+	/**
+	 * Gets more information about the user whose chat message was deleted.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].target_user_id));
+	}
+
+	/**
+	 * The ID of the broadcaster.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the message that was deleted.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].message_id;
+	}
+}

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -7,6 +7,9 @@ export { EventSubChannelCharityCampaignProgressEvent } from './events/EventSubCh
 export { EventSubChannelCharityCampaignStartEvent } from './events/EventSubChannelCharityCampaignStartEvent';
 export { EventSubChannelCharityCampaignStopEvent } from './events/EventSubChannelCharityCampaignStopEvent';
 export { EventSubChannelCharityDonationEvent } from './events/EventSubChannelCharityDonationEvent';
+export { EventSubChannelChatClearEvent } from './events/EventSubChannelChatClearEvent';
+export { EventSubChannelChatClearUserMessagesEvent } from './events/EventSubChannelChatClearUserMessagesEvent';
+export { EventSubChannelChatMessageDeleteEvent } from './events/EventSubChannelChatMessageDeleteEvent';
 export { EventSubChannelCheerEvent } from './events/EventSubChannelCheerEvent';
 export { EventSubChannelFollowEvent } from './events/EventSubChannelFollowEvent';
 export { EventSubChannelGoalBeginEvent } from './events/EventSubChannelGoalBeginEvent';

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatClearSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatClearSubscription.ts
@@ -1,0 +1,39 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import { EventSubChannelChatClearEvent } from '../events/EventSubChannelChatClearEvent';
+import { type EventSubChannelChatClearEventData } from '../events/EventSubChannelChatClearEvent.external';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelChatClearSubscription extends EventSubSubscription<EventSubChannelChatClearEvent> {
+	/** @protected */ readonly _cliName = 'chat-clear';
+
+	constructor(
+		handler: (data: EventSubChannelChatClearEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.chat.clear.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(data: EventSubChannelChatClearEventData): EventSubChannelChatClearEvent {
+		return new EventSubChannelChatClearEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelChatClearEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatClearUserMessagesSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatClearUserMessagesSubscription.ts
@@ -1,0 +1,41 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import { EventSubChannelChatClearUserMessagesEvent } from '../events/EventSubChannelChatClearUserMessagesEvent';
+import { type EventSubChannelChatClearUserMessagesEventData } from '../events/EventSubChannelChatClearUserMessagesEvent.external';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelChatClearUserMessagesSubscription extends EventSubSubscription<EventSubChannelChatClearUserMessagesEvent> {
+	/** @protected */ readonly _cliName = 'chat-clear-user-messages';
+
+	constructor(
+		handler: (data: EventSubChannelChatClearUserMessagesEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.chat.clear_user_messages.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelChatClearUserMessagesEventData,
+	): EventSubChannelChatClearUserMessagesEvent {
+		return new EventSubChannelChatClearUserMessagesEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelChatClearUserMessagesEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatMessageDeleteSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatMessageDeleteSubscription.ts
@@ -1,0 +1,39 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import { EventSubChannelChatMessageDeleteEvent } from '../events/EventSubChannelChatMessageDeleteEvent';
+import { type EventSubChannelChatMessageDeleteEventData } from '../events/EventSubChannelChatMessageDeleteEvent.external';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelChatMessageDeleteSubscription extends EventSubSubscription<EventSubChannelChatMessageDeleteEvent> {
+	/** @protected */ readonly _cliName = 'chat-message-delete';
+
+	constructor(
+		handler: (data: EventSubChannelChatMessageDeleteEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.chat.message_delete.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(data: EventSubChannelChatMessageDeleteEventData): EventSubChannelChatMessageDeleteEvent {
+		return new EventSubChannelChatMessageDeleteEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelChatMessageDeleteEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}


### PR DESCRIPTION
Type: Feature

Fixes: #535 (partial)

Adds the new EventSub events for [Chat Clear](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatclear), [Chat Clear User Messages](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatclear_user_messages), and [Chat Message Delete](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatmessage_delete)
