### PR TITLE
fix HelixPredictor user fields

### DIFF
--- a/packages/api/src/endpoints/prediction/HelixPredictor.ts
+++ b/packages/api/src/endpoints/prediction/HelixPredictor.ts
@@ -21,28 +21,28 @@ export class HelixPredictor extends DataObject<HelixPredictorData> {
 	 * The user ID of the predictor.
 	 */
 	get userId(): string {
-		return this[rawDataSymbol].id;
+		return this[rawDataSymbol].user_id;
 	}
 
 	/**
 	 * The name of the predictor.
 	 */
 	get userName(): string {
-		return this[rawDataSymbol].login;
+		return this[rawDataSymbol].user_login;
 	}
 
 	/**
 	 * The display name of the predictor.
 	 */
 	get userDisplayName(): string {
-		return this[rawDataSymbol].name;
+		return this[rawDataSymbol].user_name;
 	}
 
 	/**
 	 * Gets more information about the predictor.
 	 */
 	async getUser(): Promise<HelixUser | null> {
-		return await this._client.users.getUserById(this[rawDataSymbol].id);
+		return await this._client.users.getUserById(this[rawDataSymbol].user_id);
 	}
 
 	/**

--- a/packages/api/src/interfaces/endpoints/prediction.external.ts
+++ b/packages/api/src/interfaces/endpoints/prediction.external.ts
@@ -10,9 +10,9 @@ export type HelixPredictionOutcomeColor = 'BLUE' | 'PINK';
 
 /** @private */
 export interface HelixPredictorData {
-	id: string;
-	name: string;
-	login: string;
+	user_id: string;
+	user_name: string;
+	user_login: string;
 	channel_points_used: number;
 	channel_points_won: number | null;
 }


### PR DESCRIPTION
Type: Bugfix

Fixes: #552

Updates the backing fields for `HelixPredictor` to the correct names per [Twitch docs](https://dev.twitch.tv/docs/api/reference/#get-predictions)