### PR TITLE
add Get Moderated Channels

### DIFF
--- a/packages/api/src/endpoints/moderation/HelixModeratedChannel.ts
+++ b/packages/api/src/endpoints/moderation/HelixModeratedChannel.ts
@@ -1,0 +1,57 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import type { BaseApiClient } from '../../client/BaseApiClient';
+import type { HelixModeratedChannelData } from '../../interfaces/endpoints/moderation.external';
+import type { HelixUser } from '../user/HelixUser';
+import type { HelixChannel } from '../channel/HelixChannel';
+
+/**
+ * A reference to a Twitch channel where a user is a moderator.
+ */
+@rtfm<HelixModeratedChannel>('api', 'HelixModeratedChannel', 'id')
+export class HelixModeratedChannel extends DataObject<HelixModeratedChannelData> {
+	/** @internal */ @Enumerable(false) private readonly _client: BaseApiClient;
+
+	/** @internal */
+	constructor(data: HelixModeratedChannelData, client: BaseApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the channel.
+	 */
+	get id(): string {
+		return this[rawDataSymbol].broadcaster_id;
+	}
+
+	/**
+	 * The name of the channel.
+	 */
+	get name(): string {
+		return this[rawDataSymbol].broadcaster_login;
+	}
+
+	/**
+	 * The display name of the channel.
+	 */
+	get displayName(): string {
+		return this[rawDataSymbol].broadcaster_name;
+	}
+
+	/**
+	 * Gets more information about the channel.
+	 */
+	async getChannel(): Promise<HelixChannel> {
+		return checkRelationAssertion(
+			await this._client.channels.getChannelInfoById(this[rawDataSymbol].broadcaster_id),
+		);
+	}
+
+	/**
+	 * Gets more information about the broadcaster of the channel.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_id));
+	}
+}

--- a/packages/api/src/endpoints/moderation/HelixModerationApi.ts
+++ b/packages/api/src/endpoints/moderation/HelixModerationApi.ts
@@ -184,7 +184,7 @@ export class HelixModerationApi extends BaseApi {
 	}
 
 	/**
-	 * Creates a paginator for channels where the specified user moderator privileges.
+	 * Creates a paginator for channels where the specified user has moderator privileges.
 	 *
 	 * @param user The user for whom to return the list of channels where they have moderator privileges.
 	 * This ID must match the user ID in the access token.

--- a/packages/api/src/endpoints/moderation/HelixModerationApi.ts
+++ b/packages/api/src/endpoints/moderation/HelixModerationApi.ts
@@ -14,6 +14,7 @@ import {
 	type HelixBanData,
 	type HelixBanUserData,
 	type HelixBlockedTermData,
+	type HelixModeratedChannelData,
 	type HelixModeratorData,
 	type HelixShieldModeStatusData,
 } from '../../interfaces/endpoints/moderation.external';
@@ -34,6 +35,7 @@ import { HelixBan } from './HelixBan';
 import { HelixBanUser } from './HelixBanUser';
 import { HelixBlockedTerm } from './HelixBlockedTerm';
 import { HelixModerator } from './HelixModerator';
+import { HelixModeratedChannel } from './HelixModeratedChannel';
 import { HelixShieldModeStatus } from './HelixShieldModeStatus';
 
 /**
@@ -148,6 +150,58 @@ export class HelixModerationApi extends BaseApi {
 			},
 			this._client,
 			data => new HelixModerator(data, this._client),
+		);
+	}
+
+	/**
+	 * Gets a list of channels where the specified user has moderator privileges.
+	 *
+	 * @param user The user for whom to return a list of channels where they have moderator privileges.
+	 * This ID must match the user ID in the access token.
+	 * @param filter
+	 *
+	 * @expandParams
+	 *
+	 * @returns A paginated list of channels where the user has moderator privileges.
+	 */
+	async getModeratedChannels(
+		user: UserIdResolvable,
+		filter?: HelixForwardPagination,
+	): Promise<HelixPaginatedResult<HelixModeratedChannel>> {
+		const userId = extractUserId(user);
+		const result = await this._client.callApi<HelixPaginatedResponse<HelixModeratedChannelData>>({
+			type: 'helix',
+			url: 'moderation/channels',
+			userId,
+			scopes: ['user:read:moderated_channels'],
+			query: {
+				...createSingleKeyQuery('user_id', userId),
+				...createPaginationQuery(filter),
+			},
+		});
+
+		return createPaginatedResult(result, HelixModeratedChannel, this._client);
+	}
+
+	/**
+	 * Creates a paginator for channels where the specified user moderator privileges.
+	 *
+	 * @param user The user for whom to return the list of channels where they have moderator privileges.
+	 * This ID must match the user ID in the access token.
+	 */
+	getModeratedChannelsPaginated(
+		user: UserIdResolvable,
+	): HelixPaginatedRequest<HelixModeratedChannelData, HelixModeratedChannel> {
+		const userId = extractUserId(user);
+		return new HelixPaginatedRequest<HelixModeratedChannelData, HelixModeratedChannel>(
+			{
+				url: 'moderation/channels',
+				userId,
+				scopes: ['user:read:moderated_channels'],
+				query: createSingleKeyQuery('user_id', userId),
+			},
+			this._client,
+			data => new HelixModeratedChannel(data, this._client),
 		);
 	}
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -126,6 +126,7 @@ export type {
 export { HelixModerationApi } from './endpoints/moderation/HelixModerationApi';
 export { HelixBan } from './endpoints/moderation/HelixBan';
 export { HelixModerator } from './endpoints/moderation/HelixModerator';
+export { HelixModeratedChannel } from './endpoints/moderation/HelixModeratedChannel';
 export { HelixBanUser } from './endpoints/moderation/HelixBanUser';
 export { HelixBlockedTerm } from './endpoints/moderation/HelixBlockedTerm';
 export { HelixShieldModeStatus } from './endpoints/moderation/HelixShieldModeStatus';

--- a/packages/api/src/interfaces/endpoints/moderation.external.ts
+++ b/packages/api/src/interfaces/endpoints/moderation.external.ts
@@ -70,6 +70,13 @@ export interface HelixModeratorData {
 }
 
 /** @private */
+export interface HelixModeratedChannelData {
+	broadcaster_id: string;
+	broadcaster_login: string;
+	broadcaster_name: string;
+}
+
+/** @private */
 export interface HelixShieldModeStatusData {
 	is_active: boolean;
 	moderator_id: string;


### PR DESCRIPTION
Type: Feature 

Fixes: #551

Adds new [Get Moderated Channels](https://dev.twitch.tv/docs/api/reference/#get-moderated-channels) endpoint and paginated endpoint