### PR TITLE
Update scope for user extensions endpoints

### DIFF
--- a/packages/api/src/endpoints/user/HelixUserApi.ts
+++ b/packages/api/src/endpoints/user/HelixUserApi.ts
@@ -280,7 +280,7 @@ export class HelixUserApi extends BaseApi {
 			type: 'helix',
 			url: 'users/extensions/list',
 			userId: extractUserId(broadcaster),
-			scopes: withInactive ? ['user:edit:broadcast'] : ['user:read:broadcast', 'user:edit:broadcast'],
+			scopes: withInactive ? ['channel:manage:extensions'] : ['user:read:broadcast', 'channel:manage:extensions'],
 		});
 
 		return result.data.map(data => new HelixUserExtension(data));
@@ -298,7 +298,7 @@ export class HelixUserApi extends BaseApi {
 			type: 'helix',
 			url: 'users/extensions',
 			userId,
-			scopes: withDev ? ['user:read:broadcast', 'user:edit:broadcast'] : undefined,
+			scopes: withDev ? ['user:read:broadcast', 'channel:manage:extensions'] : undefined,
 			query: createSingleKeyQuery('user_id', userId),
 		});
 
@@ -323,7 +323,7 @@ export class HelixUserApi extends BaseApi {
 			url: 'users/extensions',
 			method: 'PUT',
 			userId: extractUserId(broadcaster),
-			scopes: ['user:edit:broadcast'],
+			scopes: ['channel:manage:extensions'],
 			jsonBody: { data },
 		});
 

--- a/packages/auth/src/__tests__/helpers.test.ts
+++ b/packages/auth/src/__tests__/helpers.test.ts
@@ -42,6 +42,7 @@ describe('compareScopes', () => {
 
 	it('avoids undesired reverse scope equivalencies', () => {
 		expectError(['channel:manage:broadcast'], ['user:edit:broadcast']);
+		expectError(['channel:manage:extensions'], ['user:edit:broadcast']);
 	});
 });
 


### PR DESCRIPTION
<!--
Please enter "Bugfix", "Improvement" or "Feature" here.
Major features will only get included in new major and minor versions and should be based on the main branch,
while small improvements and bugfixes will be released to `@latest` more quickly and should be based on the version branch of the current minor version, e.g. `versions/4.4`.
Don't worry - bugfixes will also be merged back to the main branch, if applicable.
-->
Type: Bugfix
<!--
Enter the issue ID(s) of the issue(s) this pull request fixes here.
PLEASE DO NOT SUBMIT PULL REQUESTS WITHOUT FIRST FILING AN ISSUE!
In case of bugs, no further discussion is required and you can submit a fix immediately.
For improvements and features, please allow for at least 24 hours after filing the issue for discussion about a shallow plan whether and how it should be implemented in order to not waste your time.
-->
Fixes: #560 

<!-- Here you can explain in further detail what your pull request contains. -->
The PR just replaces the requirement of `user:edit:broadcast` with `channel:manage:extensions` in the corresponding endpoints, the same way `channel:manage:broadcast` was used as a replacement for other endpoints in a past commit. Using a token with `user:edit:broadcast` still works as before since there's already a comparison equivalency defined in the auth package:

https://github.com/twurple/twurple/blob/9b94eee032a9089a276b23624ffc3d0326b5e06e/packages/auth/src/helpers.ts#L230-L241

Also added a minor test case you ensure no reverse `channel:manage:extensions` -> `user:edit:broadcast` ever happens

Basing this on the main branch since being a minor bugfix/improvement you probably won't backport this to 7.0