### PR TITLE
feat(eventsub): add automod events

### DIFF
--- a/docs/getting-data/index.md
+++ b/docs/getting-data/index.md
@@ -53,26 +53,26 @@ should use for which use case.
 
 ## Events
 
-| Event type                             | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub-*`      |
-|----------------------------------------|------------------------------|---------------------------|----------------------------|
-| Chat messages                          | Yes                          | Sub & cheer messages only | Yes                        |
-| Chat mode (e.g. sub only) changes      | Yes                          | No                        | Yes                        |
-| Whispers                               | Yes                          | Yes                       | No (in beta by Twitch)     |
-| Cheers                                 | Yes                          | Yes                       | Yes                        |
-| Channel points                         | Redemptions w/ messages only | Redemptions only          | Yes                        |
-| Subscriptions                          | Published only               | Published only            | Yes                        |
-| AutoMod                                | No                           | Yes                       | No (implemented by Twitch) |
-| Live / offline / stream changes        | No                           | No                        | Yes                        |
-| Follows                                | No                           | No                        | Yes                        |
-| Raids                                  | Yes                          | No                        | Yes                        |
-| Bans                                   | Yes                          | Yes                       | Yes                        |
-| Mod add/remove                         | No                           | Yes                       | Yes                        |
-| Polls & predictions                    | No                           | No                        | Yes                        |
-| Extension transactions                 | No                           | No                        | Yes                        |
-| Hype Trains                            | No                           | No                        | Yes                        |
-| Authorization grant/revoke             | No                           | No                        | Yes                        |
-| Drops                                  | No                           | No                        | Yes                        |
-| Charity campaigns & donations          | No                           | No                        | Yes                        |
-| Shield mode begin/end                  | No                           | No                        | Yes                        |
-| Unban request approve/deny             | No                           | Yes                       | No (in beta by Twitch)     |
-| Low-trust users treatment/chat message | No                           | Yes                       | No (in beta by Twitch)     |
+| Event type                             | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub-*`  |
+|----------------------------------------|------------------------------|---------------------------|------------------------|
+| Chat messages                          | Yes                          | Sub & cheer messages only | Yes                    |
+| Chat mode (e.g. sub only) changes      | Yes                          | No                        | Yes                    |
+| Whispers                               | Yes                          | Yes                       | No (in beta by Twitch) |
+| Cheers                                 | Yes                          | Yes                       | Yes                    |
+| Channel points                         | Redemptions w/ messages only | Redemptions only          | Yes                    |
+| Subscriptions                          | Published only               | Published only            | Yes                    |
+| AutoMod                                | No                           | Yes                       | Yes                    |
+| Live / offline / stream changes        | No                           | No                        | Yes                    |
+| Follows                                | No                           | No                        | Yes                    |
+| Raids                                  | Yes                          | No                        | Yes                    |
+| Bans                                   | Yes                          | Yes                       | Yes                    |
+| Mod add/remove                         | No                           | Yes                       | Yes                    |
+| Polls & predictions                    | No                           | No                        | Yes                    |
+| Extension transactions                 | No                           | No                        | Yes                    |
+| Hype Trains                            | No                           | No                        | Yes                    |
+| Authorization grant/revoke             | No                           | No                        | Yes                    |
+| Drops                                  | No                           | No                        | Yes                    |
+| Charity campaigns & donations          | No                           | No                        | Yes                    |
+| Shield mode begin/end                  | No                           | No                        | Yes                    |
+| Unban request approve/deny             | No                           | Yes                       | No (in beta by Twitch) |
+| Low-trust users treatment/chat message | No                           | Yes                       | No (in beta by Twitch) |

--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -1500,6 +1500,138 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribes to events that represent a chat message being held by AutoMod.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to AutoMod message hold events for.
+	 * @param transport The transport options.
+	 */
+	async subscribeToAutoModMessageHoldEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'automod.message.hold',
+			'1',
+			createEventSubModeratorCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['moderator:manage:automod'],
+			true,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a held chat message by AutoMod being resolved.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to AutoMod message resolution events for.
+	 * @param transport The transport options.
+	 */
+	async subscribeToAutoModMessageUpdateEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'automod.message.update',
+			'1',
+			createEventSubModeratorCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['moderator:manage:automod'],
+			true,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent the AutoMod settings being updated.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to AutoMod settings update events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToAutoModSettingsUpdateEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'automod.settings.update',
+			'1',
+			createEventSubModeratorCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['moderator:read:automod_settings'],
+			true,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent the AutoMod terms being updated.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to AutoMod terms update events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToAutoModTermsUpdateEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'automod.terms.update',
+			'1',
+			createEventSubModeratorCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['moderator:manage:automod'],
+			true,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a user's notification about their message being held by AutoMod.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to AutoMod message hold events for.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelChatUserMessageHoldEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.chat.user_message_hold',
+			'1',
+			createEventSubUserCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['user:read:chat'],
+			true,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a user's notification about a held chat message by AutoMod being resolved.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to AutoMod message resolution events for.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelChatUserMessageUpdateEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.chat.user_message_update',
+			'1',
+			createEventSubUserCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['user:read:chat'],
+			true,
+		);
+	}
+
+	/**
 	 * Gets the current EventSub conduits for the current client.
 	 *
 	 */

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -117,6 +117,18 @@ import type { EventSubSubscription } from './subscriptions/EventSubSubscription'
 import { EventSubUserAuthorizationGrantSubscription } from './subscriptions/EventSubUserAuthorizationGrantSubscription';
 import { EventSubUserAuthorizationRevokeSubscription } from './subscriptions/EventSubUserAuthorizationRevokeSubscription';
 import { EventSubUserUpdateSubscription } from './subscriptions/EventSubUserUpdateSubscription';
+import type { EventSubAutoModMessageHoldEvent } from './events/EventSubAutoModMessageHoldEvent';
+import { EventSubAutoModMessageHoldSubscription } from './subscriptions/EventSubAutoModMessageHoldSubscription';
+import type { EventSubAutoModMessageUpdateEvent } from './events/EventSubAutoModMessageUpdateEvent';
+import { EventSubAutoModMessageUpdateSubscription } from './subscriptions/EventSubAutoModMessageUpdateSubscription';
+import type { EventSubAutoModSettingsUpdateEvent } from './events/EventSubAutoModSettingsUpdateEvent';
+import { EventSubAutoModSettingsUpdateSubscription } from './subscriptions/EventSubAutoModSettingsUpdateSubscription';
+import type { EventSubAutoModTermsUpdateEvent } from './events/EventSubAutoModTermsUpdateEvent';
+import { EventSubAutoModTermsUpdateSubscription } from './subscriptions/EventSubAutoModTermsUpdateSubscription';
+import { EventSubChannelChatUserMessageHoldSubscription } from './subscriptions/EventSubChannelChatUserMessageHoldSubscription';
+import { type EventSubChannelChatUserMessageHoldEvent } from './events/EventSubChannelChatUserMessageHoldEvent';
+import { type EventSubChannelChatUserMessageUpdateEvent } from './events/EventSubChannelChatUserMessageUpdateEvent';
+import { EventSubChannelChatUserMessageUpdateSubscription } from './subscriptions/EventSubChannelChatUserMessageUpdateSubscription';
 
 const numberRegex = /^\d+$/;
 
@@ -1208,6 +1220,150 @@ export abstract class EventSubBase extends EventEmitter {
 	): EventSubSubscription {
 		const { clientId } = this._apiClient._authProvider;
 		return this._genericSubscribe(EventSubExtensionBitsTransactionCreateSubscription, handler, this, clientId);
+	}
+
+	/**
+	 * Subscribes to events that represent a chat message being held by AutoMod in a channel.
+	 *
+	 * @param broadcaster A broadcaster for which to get notifications about the held messages.
+	 * @param moderator A user that has permission to manage AutoMod in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModMessageHold(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModMessageHoldEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onAutoModMessageHold');
+		const moderatorId = this._extractUserIdWithNumericWarning(moderator, 'onAutoModMessageHold');
+
+		return this._genericSubscribe(
+			EventSubAutoModMessageHoldSubscription,
+			handler,
+			this,
+			broadcasterId,
+			moderatorId,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a held chat message by AutoMod being resolved in a channel.
+	 *
+	 * @param broadcaster A Broadcaster for which to get notifications about resolution of held messages.
+	 * @param moderator A user that has permission to manage AutoMod in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModMessageUpdate(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModMessageUpdateEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onAutoModMessageUpdate');
+		const moderatorId = this._extractUserIdWithNumericWarning(moderator, 'onAutoModMessageUpdate');
+
+		return this._genericSubscribe(
+			EventSubAutoModMessageUpdateSubscription,
+			handler,
+			this,
+			broadcasterId,
+			moderatorId,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent the AutoMod settings being updated in a channel.
+	 *
+	 * @param broadcaster A user for which to get notifications about AutoMod settings update.
+	 * @param moderator A user that has permission to manage AutoMod settings in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModSettingsUpdate(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModSettingsUpdateEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onAutoModSettingsUpdate');
+		const moderatorId = this._extractUserIdWithNumericWarning(moderator, 'onAutoModSettingsUpdate');
+
+		return this._genericSubscribe(
+			EventSubAutoModSettingsUpdateSubscription,
+			handler,
+			this,
+			broadcasterId,
+			moderatorId,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent AutoMod terms being updated in a channel.
+	 *
+	 * @param broadcaster A user for which to get notifications about AutoMod terms update.
+	 * @param moderator A user that has permission to manage AutoMod in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModTermsUpdate(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModTermsUpdateEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onAutoModTermsUpdate');
+		const moderatorId = this._extractUserIdWithNumericWarning(moderator, 'onAutoModTermsUpdate');
+
+		return this._genericSubscribe(
+			EventSubAutoModTermsUpdateSubscription,
+			handler,
+			this,
+			broadcasterId,
+			moderatorId,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a user's notification about their chat message being held by AutoMod.
+	 *
+	 * @param broadcaster A broadcaster in which channel to get notifications about held messages.
+	 * @param user A user that has permission to read chat in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatUserMessageHold(
+		broadcaster: UserIdResolvable,
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatUserMessageHoldEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelChatUserMessageHold');
+		const userId = this._extractUserIdWithNumericWarning(user, 'onChannelChatUserMessageHold');
+
+		return this._genericSubscribe(
+			EventSubChannelChatUserMessageHoldSubscription,
+			handler,
+			this,
+			broadcasterId,
+			userId,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a user's notification about their held chat message being resolved.
+	 *
+	 * @param broadcaster The user for which to get notifications about resolution of held messages.
+	 * @param user A user that has permission to read chat in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatUserMessageUpdate(
+		broadcaster: UserIdResolvable,
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatUserMessageUpdateEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelChatUserMessageUpdate');
+		const userId = this._extractUserIdWithNumericWarning(user, 'onChannelChatUserMessageUpdate');
+
+		return this._genericSubscribe(
+			EventSubChannelChatUserMessageUpdateSubscription,
+			handler,
+			this,
+			broadcasterId,
+			userId,
+		);
 	}
 
 	/**

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -52,6 +52,12 @@ import type { EventSubUserAuthorizationGrantEvent } from './events/EventSubUserA
 import type { EventSubUserAuthorizationRevokeEvent } from './events/EventSubUserAuthorizationRevokeEvent';
 import type { EventSubUserUpdateEvent } from './events/EventSubUserUpdateEvent';
 import type { EventSubSubscription } from './subscriptions/EventSubSubscription';
+import { type EventSubAutoModMessageHoldEvent } from './events/EventSubAutoModMessageHoldEvent';
+import { type EventSubAutoModMessageUpdateEvent } from './events/EventSubAutoModMessageUpdateEvent';
+import { type EventSubAutoModSettingsUpdateEvent } from './events/EventSubAutoModSettingsUpdateEvent';
+import { type EventSubAutoModTermsUpdateEvent } from './events/EventSubAutoModTermsUpdateEvent';
+import { type EventSubChannelChatUserMessageHoldEvent } from './events/EventSubChannelChatUserMessageHoldEvent';
+import { type EventSubChannelChatUserMessageUpdateEvent } from './events/EventSubChannelChatUserMessageUpdateEvent';
 
 /**
  * The common interface of all EventSub listeners.
@@ -710,6 +716,84 @@ export interface EventSubListener {
 	 */
 	onExtensionBitsTransactionCreate: (
 		handler: (event: EventSubExtensionBitsTransactionCreateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a chat message being held by AutoMod in a channel.
+	 *
+	 * @param broadcaster A broadcaster for which to get notifications about the held messages.
+	 * @param moderator A user that has permission to manage AutoMod in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModMessageHold: (
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModMessageHoldEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a held chat message by AutoMod being resolved in a channel.
+	 *
+	 * @param broadcaster A Broadcaster for which to get notifications about resolution of held messages.
+	 * @param moderator A user that has permission to manage AutoMod in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModMessageUpdate: (
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModMessageUpdateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent the AutoMod settings being updated in a channel.
+	 *
+	 * @param broadcaster A user for which to get notifications about AutoMod settings update.
+	 * @param moderator A user that has permission to manage AutoMod settings in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModSettingsUpdate: (
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModSettingsUpdateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent AutoMod terms being updated in a channel.
+	 *
+	 * @param broadcaster A user for which to get notifications about AutoMod terms update.
+	 * @param moderator A user that has permission to manage AutoMod in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onAutoModTermsUpdate: (
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (data: EventSubAutoModTermsUpdateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a user's notification about their chat message has been held by AutoMod.
+	 *
+	 * @param broadcaster A broadcaster in which channel to get notifications about held messages by AutoMod.
+	 * @param moderator A user that has permission to read chat in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatUserMessageHold: (
+		broadcaster: UserIdResolvable,
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatUserMessageHoldEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a user's notification about the resolution of a held chat message by AutoMod.
+	 *
+	 * @param broadcaster The user for which to get notifications about resolution of messages held by AutoMod.
+	 * @param moderator A user that has permission to read chat in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelChatUserMessageUpdate: (
+		broadcaster: UserIdResolvable,
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelChatUserMessageUpdateEvent) => void,
 	) => EventSubSubscription;
 
 	/**

--- a/packages/eventsub-base/src/events/EventSubAutoModMessageHoldEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModMessageHoldEvent.external.ts
@@ -1,0 +1,17 @@
+import { type EventSubAutoModLevel } from './common/EventSubAutoModLevel';
+import { type EventSubAutoModMessageData } from './common/EventSubAutoModMessage.external';
+
+/** @private */
+export interface EventSubAutoModMessageHoldEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_name: string;
+	broadcaster_user_login: string;
+	user_id: string;
+	user_name: string;
+	user_login: string;
+	message_id: string;
+	message: EventSubAutoModMessageData;
+	level: EventSubAutoModLevel;
+	category: string;
+	held_at: string;
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModMessageHoldEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModMessageHoldEvent.ts
@@ -1,0 +1,118 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubAutoModMessageHoldEventData } from './EventSubAutoModMessageHoldEvent.external';
+import { type EventSubAutoModLevel } from './common/EventSubAutoModLevel';
+import { type EventSubAutoModMessagePart } from './common/EventSubAutoModMessage.external';
+
+/**
+ * An EventSub event representing chat message being held by AutoMod in a channel.
+ */
+@rtfm<EventSubAutoModMessageHoldEvent>('eventsub-base', 'EventSubAutoModMessageHoldEvent', 'messageId')
+export class EventSubAutoModMessageHoldEvent extends DataObject<EventSubAutoModMessageHoldEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubAutoModMessageHoldEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose channel the message has been held by AutoMod.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose channel the message has been held by AutoMod.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in whose channel the message has been held by AutoMod.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the user whose message has been held by AutoMod.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the user whose message has been held by AutoMod.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the user whose message has been held by AutoMod.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * The ID of the chat message held by AutoMod.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].message_id;
+	}
+
+	/**
+	 * The plain text of the message.
+	 */
+	get messageText(): string {
+		return this[rawDataSymbol].message.text;
+	}
+
+	/**
+	 * The pre-parsed message parts.
+	 */
+	get messageParts(): EventSubAutoModMessagePart[] {
+		return this[rawDataSymbol].message.fragments;
+	}
+
+	/**
+	 * The category of the message.
+	 */
+	get category(): string {
+		return this[rawDataSymbol].category;
+	}
+
+	/**
+	 * The level of severity.
+	 */
+	get level(): EventSubAutoModLevel {
+		return this[rawDataSymbol].level;
+	}
+
+	/**
+	 * The date of when AutoMod held the message.
+	 */
+	get holdDate(): Date {
+		return new Date(this[rawDataSymbol].held_at);
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModMessageUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModMessageUpdateEvent.external.ts
@@ -1,0 +1,22 @@
+import { type EventSubAutoModLevel } from './common/EventSubAutoModLevel';
+import { type EventSubAutoModMessageData } from './common/EventSubAutoModMessage.external';
+import { type EventSubAutoModResolutionStatus } from './common/EventSubAutoModResolutionStatus';
+
+/** @private */
+export interface EventSubAutoModMessageUpdateEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	moderator_user_id: string;
+	moderator_user_login: string;
+	moderator_user_name: string;
+	user_id: string;
+	user_login: string;
+	user_name: string;
+	message_id: string;
+	message: EventSubAutoModMessageData;
+	level: EventSubAutoModLevel;
+	category: string;
+	status: EventSubAutoModResolutionStatus;
+	held_at: string;
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModMessageUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModMessageUpdateEvent.ts
@@ -1,0 +1,154 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubAutoModLevel } from './common/EventSubAutoModLevel';
+import { type EventSubAutoModMessagePart } from './common/EventSubAutoModMessage.external';
+import { type EventSubAutoModMessageUpdateEventData } from './EventSubAutoModMessageUpdateEvent.external';
+import { type EventSubAutoModResolutionStatus } from './common/EventSubAutoModResolutionStatus';
+
+/**
+ * An EventSub event representing a held chat message by AutoMod being resolved in a channel.
+ */
+@rtfm<EventSubAutoModMessageUpdateEvent>('eventsub-base', 'EventSubAutoModMessageUpdateEvent', 'messageId')
+export class EventSubAutoModMessageUpdateEvent extends DataObject<EventSubAutoModMessageUpdateEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubAutoModMessageUpdateEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose channel the held message was resolved.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose channel the held message was resolved.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in channel the held message was resolved.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the moderator who resolved the held message.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the moderator who resolved the held message.
+	 */
+	get moderatorName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the moderator who resolved the held message.
+	 */
+	get moderatorDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the moderator.
+	 */
+	async getModerator(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].moderator_user_id));
+	}
+
+	/**
+	 * The ID of the user whose message was held by AutoMod.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the user whose message was held by AutoMod.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the user whose message was held by AutoMod.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * The ID of the message held by AutoMod.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].message_id;
+	}
+
+	/**
+	 * The plain text of the message.
+	 */
+	get messageText(): string {
+		return this[rawDataSymbol].message.text;
+	}
+
+	/**
+	 * The pre-parsed message parts.
+	 */
+	get messageParts(): EventSubAutoModMessagePart[] {
+		return this[rawDataSymbol].message.fragments;
+	}
+
+	/**
+	 * The category of the message.
+	 */
+	get category(): string {
+		return this[rawDataSymbol].category;
+	}
+
+	/**
+	 * The level of severity.
+	 */
+	get level(): EventSubAutoModLevel {
+		return this[rawDataSymbol].level;
+	}
+
+	/**
+	 * The status of the resolved message.
+	 */
+	get status(): EventSubAutoModResolutionStatus {
+		return this[rawDataSymbol].status;
+	}
+
+	/**
+	 * The date of when AutoMod held the message.
+	 */
+	get holdDate(): Date {
+		return new Date(this[rawDataSymbol].held_at);
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModSettingsUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModSettingsUpdateEvent.external.ts
@@ -1,0 +1,20 @@
+import { type EventSubAutoModLevel } from './common/EventSubAutoModLevel';
+
+/** @private */
+export interface EventSubAutoModSettingsUpdateEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	moderator_user_id: string;
+	moderator_user_login: string;
+	moderator_user_name: string;
+	overall_level: EventSubAutoModLevel | null;
+	disability: EventSubAutoModLevel;
+	aggression: EventSubAutoModLevel;
+	sexuality_sex_or_gender: EventSubAutoModLevel;
+	misogyny: EventSubAutoModLevel;
+	bullying: EventSubAutoModLevel;
+	swearing: EventSubAutoModLevel;
+	race_ethnicity_or_religion: EventSubAutoModLevel;
+	sex_based_terms: EventSubAutoModLevel;
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModSettingsUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModSettingsUpdateEvent.ts
@@ -1,0 +1,140 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubAutoModLevel } from './common/EventSubAutoModLevel';
+import { type EventSubAutoModSettingsUpdateEventData } from './EventSubAutoModSettingsUpdateEvent.external';
+
+/**
+ * An EventSub event representing the AutoMod settings being updated in a channel.
+ */
+@rtfm<EventSubAutoModSettingsUpdateEvent>('eventsub-base', 'EventSubAutoModSettingsUpdateEvent', 'broadcasterId')
+export class EventSubAutoModSettingsUpdateEvent extends DataObject<EventSubAutoModSettingsUpdateEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubAutoModSettingsUpdateEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose channel the AutoMod settings were updated.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose channel the AutoMod settings were changed.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in whose channel the AutoMod settings were changed.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the moderator who changed the AutoMod settings.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].moderator_user_id;
+	}
+
+	/**
+	 * The name of the moderator who changed the AutoMod settings.
+	 */
+	get moderatorName(): string {
+		return this[rawDataSymbol].moderator_user_login;
+	}
+
+	/**
+	 * The display name of the moderator who changed the AutoMod settings.
+	 */
+	get moderatorDisplayName(): string {
+		return this[rawDataSymbol].moderator_user_name;
+	}
+
+	/**
+	 * Gets more information about the moderator.
+	 */
+	async getModerator(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].moderator_user_id));
+	}
+
+	/**
+	 * The default AutoMod level for the broadcaster.
+	 *
+	 * This field is `null` if the broadcaster has set one or more of the individual settings.
+	 */
+	get overallLevel(): EventSubAutoModLevel | null {
+		return this[rawDataSymbol].overall_level;
+	}
+
+	/**
+	 * The AutoMod level for hostility involving aggression.
+	 */
+	get aggression(): EventSubAutoModLevel {
+		return this[rawDataSymbol].aggression;
+	}
+
+	/**
+	 * The AutoMod level for hostility involving name-calling, insults, or antagonization.
+	 */
+	get bullying(): EventSubAutoModLevel {
+		return this[rawDataSymbol].bullying;
+	}
+
+	/**
+	 * The AutoMod level for discrimination against perceived or actual mental or physical abilities.
+	 */
+	get disability(): EventSubAutoModLevel {
+		return this[rawDataSymbol].disability;
+	}
+
+	/**
+	 * The AutoMod level for discrimination against women.
+	 */
+	get misogyny(): EventSubAutoModLevel {
+		return this[rawDataSymbol].misogyny;
+	}
+
+	/**
+	 * The AutoMod level for discrimination based on race, ethnicity, or religion.
+	 */
+	get raceEthnicityOrReligion(): EventSubAutoModLevel {
+		return this[rawDataSymbol].race_ethnicity_or_religion;
+	}
+
+	/**
+	 * The AutoMod level for sex-based terms, e.g. sexual acts or anatomy.
+	 */
+	get sexBasedTerms(): EventSubAutoModLevel {
+		return this[rawDataSymbol].sex_based_terms;
+	}
+
+	/**
+	 * The AutoMod level for discrimination based on sexuality, sex, or gender.
+	 */
+	get sexualitySexOrGender(): EventSubAutoModLevel {
+		return this[rawDataSymbol].sexuality_sex_or_gender;
+	}
+
+	/**
+	 * The AutoMod level for profanity.
+	 */
+	get swearing(): EventSubAutoModLevel {
+		return this[rawDataSymbol].swearing;
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModTermsUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModTermsUpdateEvent.external.ts
@@ -1,0 +1,17 @@
+/**
+ * The status change applied to the terms.
+ */
+export type EventSubAutoModTermsUpdateAction = 'add_permitted' | 'remove_permitted' | 'add_blocked' | 'remove_blocked';
+
+/** @private */
+export interface EventSubAutoModTermsUpdateEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	moderator_user_id: string;
+	moderator_user_login: string;
+	moderator_user_name: string;
+	action: EventSubAutoModTermsUpdateAction;
+	from_automod: boolean;
+	terms: string[];
+}

--- a/packages/eventsub-base/src/events/EventSubAutoModTermsUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubAutoModTermsUpdateEvent.ts
@@ -1,0 +1,98 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import {
+	type EventSubAutoModTermsUpdateAction,
+	type EventSubAutoModTermsUpdateEventData,
+} from './EventSubAutoModTermsUpdateEvent.external';
+
+/**
+ * An EventSub event representing AutoMod terms being updated in a channel.
+ */
+@rtfm<EventSubAutoModTermsUpdateEvent>('eventsub-base', 'EventSubAutoModTermsUpdateEvent', 'broadcasterId')
+export class EventSubAutoModTermsUpdateEvent extends DataObject<EventSubAutoModTermsUpdateEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubAutoModTermsUpdateEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose channel AutoMod terms were updated.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose channel AutoMod terms were updated.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in whose channel AutoMod terms were updated.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the moderator who updated AutoMod terms.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].moderator_user_id;
+	}
+
+	/**
+	 * The name of the moderator who updated AutoMod terms.
+	 */
+	get moderatorName(): string {
+		return this[rawDataSymbol].moderator_user_login;
+	}
+
+	/**
+	 * The display name of the moderator who updated AutoMod terms.
+	 */
+	get moderatorDisplayName(): string {
+		return this[rawDataSymbol].moderator_user_name;
+	}
+
+	/**
+	 * Gets more information about the moderator.
+	 */
+	async getModerator(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].moderator_user_id));
+	}
+
+	/**
+	 * The status change applied to the terms.
+	 */
+	get action(): EventSubAutoModTermsUpdateAction {
+		return this[rawDataSymbol].action;
+	}
+
+	/**
+	 * Indicates whether this term was added due to an AutoMod message resolution action.
+	 */
+	get fromAutoMod(): boolean {
+		return this[rawDataSymbol].from_automod;
+	}
+
+	/**
+	 * The list of terms that had a status change.
+	 */
+	get terms(): string[] {
+		return this[rawDataSymbol].terms;
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatUserMessageHoldEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatUserMessageHoldEvent.external.ts
@@ -1,0 +1,13 @@
+import { type EventSubAutoModMessageData } from './common/EventSubAutoModMessage.external';
+
+/** @private */
+export interface EventSubChannelChatUserMessageHoldEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_name: string;
+	broadcaster_user_login: string;
+	user_id: string;
+	user_name: string;
+	user_login: string;
+	message_id: string;
+	message: EventSubAutoModMessageData;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatUserMessageHoldEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatUserMessageHoldEvent.ts
@@ -1,0 +1,96 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubAutoModMessagePart } from './common/EventSubAutoModMessage.external';
+import { type EventSubChannelChatUserMessageHoldEventData } from './EventSubChannelChatUserMessageHoldEvent.external';
+
+/**
+ * An EventSub event representing a user's notification about their chat message is being held by AutoMod.
+ */
+@rtfm<EventSubChannelChatUserMessageHoldEvent>('eventsub-base', 'EventSubChannelChatUserMessageHoldEvent', 'messageId')
+export class EventSubChannelChatUserMessageHoldEvent extends DataObject<EventSubChannelChatUserMessageHoldEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelChatUserMessageHoldEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose chat AutoMod held the message.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose chat AutoMod held the message.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in whose chat AutoMod held the message.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the user whose message is being held by AutoMod.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the user whose message is being held by AutoMod.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the user whose message is being held by AutoMod.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * The ID of the message held by AutoMod.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].message_id;
+	}
+
+	/**
+	 * The plain text of the message.
+	 */
+	get messageText(): string {
+		return this[rawDataSymbol].message.text;
+	}
+
+	/**
+	 * The pre-parsed message parts.
+	 */
+	get messageParts(): EventSubAutoModMessagePart[] {
+		return this[rawDataSymbol].message.fragments;
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatUserMessageUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatUserMessageUpdateEvent.external.ts
@@ -1,0 +1,15 @@
+import { type EventSubAutoModMessageData } from './common/EventSubAutoModMessage.external';
+import { type EventSubAutoModResolutionStatus } from './common/EventSubAutoModResolutionStatus';
+
+/** @private */
+export interface EventSubChannelChatUserMessageUpdateEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	user_id: string;
+	user_login: string;
+	user_name: string;
+	message_id: string;
+	message: EventSubAutoModMessageData;
+	status: EventSubAutoModResolutionStatus;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelChatUserMessageUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatUserMessageUpdateEvent.ts
@@ -1,0 +1,108 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubAutoModMessagePart } from './common/EventSubAutoModMessage.external';
+import { type EventSubAutoModResolutionStatus } from './common/EventSubAutoModResolutionStatus';
+import { type EventSubChannelChatUserMessageUpdateEventData } from './EventSubChannelChatUserMessageUpdateEvent.external';
+
+/**
+ * An EventSub event representing a user's notification about the resolution of their held chat message by AutoMod.
+ */
+@rtfm<EventSubChannelChatUserMessageUpdateEvent>(
+	'eventsub-base',
+	'EventSubChannelChatUserMessageUpdateEvent',
+	'messageId',
+)
+export class EventSubChannelChatUserMessageUpdateEvent extends DataObject<EventSubChannelChatUserMessageUpdateEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelChatUserMessageUpdateEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose chat the held message was resolved.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose chat the held message was resolved.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in whose chat the held message was resolved.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the user whose message is being held by AutoMod.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the user whose message is being held by AutoMod.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the user whose message is being held by AutoMod.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * The ID of the message held by AutoMod.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].message_id;
+	}
+
+	/**
+	 * The plain text of the message.
+	 */
+	get messageText(): string {
+		return this[rawDataSymbol].message.text;
+	}
+
+	/**
+	 * The pre-parsed message parts.
+	 */
+	get messageParts(): EventSubAutoModMessagePart[] {
+		return this[rawDataSymbol].message.fragments;
+	}
+
+	/**
+	 * The status of the resolved message.
+	 */
+	get status(): EventSubAutoModResolutionStatus {
+		return this[rawDataSymbol].status;
+	}
+}

--- a/packages/eventsub-base/src/events/common/EventSubAutoModLevel.ts
+++ b/packages/eventsub-base/src/events/common/EventSubAutoModLevel.ts
@@ -1,0 +1,4 @@
+/**
+ * The AutoMod level of severity.
+ */
+export type EventSubAutoModLevel = 0 | 1 | 2 | 3 | 4;

--- a/packages/eventsub-base/src/events/common/EventSubAutoModMessage.external.ts
+++ b/packages/eventsub-base/src/events/common/EventSubAutoModMessage.external.ts
@@ -1,0 +1,17 @@
+import {
+	type EventSubChatMessageCheermotePart,
+	type EventSubChatMessageEmotePart,
+	type EventSubChatMessageTextPart,
+} from './EventSubChatMessage.external';
+
+/** @private */
+export type EventSubAutoModMessagePart =
+	| EventSubChatMessageTextPart
+	| EventSubChatMessageCheermotePart
+	| EventSubChatMessageEmotePart;
+
+/** @private */
+export interface EventSubAutoModMessageData {
+	text: string;
+	fragments: EventSubAutoModMessagePart[];
+}

--- a/packages/eventsub-base/src/events/common/EventSubAutoModResolutionStatus.ts
+++ b/packages/eventsub-base/src/events/common/EventSubAutoModResolutionStatus.ts
@@ -1,0 +1,4 @@
+/**
+ * The status of the resolved AutoMod message.
+ */
+export type EventSubAutoModResolutionStatus = 'approved' | 'denied' | 'expired';

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -64,7 +64,16 @@ export { EventSubUserUpdateEvent } from './events/EventSubUserUpdateEvent';
 export { EventSubChannelUnbanRequestCreateEvent } from './events/EventSubChannelUnbanRequestCreateEvent';
 export type { EventSubChannelUnbanRequestStatus } from './events/EventSubChannelUnbanRequestResolveEvent.external';
 export { EventSubChannelUnbanRequestResolveEvent } from './events/EventSubChannelUnbanRequestResolveEvent';
+export { EventSubAutoModMessageHoldEvent } from './events/EventSubAutoModMessageHoldEvent';
+export { EventSubAutoModMessageUpdateEvent } from './events/EventSubAutoModMessageUpdateEvent';
+export type { EventSubAutoModSettingsUpdateEvent } from './events/EventSubAutoModSettingsUpdateEvent';
+export type { EventSubAutoModTermsUpdateEvent } from './events/EventSubAutoModTermsUpdateEvent';
+export type { EventSubAutoModTermsUpdateAction } from './events/EventSubAutoModTermsUpdateEvent.external';
+export type { EventSubChannelChatUserMessageHoldEvent } from './events/EventSubChannelChatUserMessageHoldEvent';
+export type { EventSubChannelChatUserMessageUpdateEvent } from './events/EventSubChannelChatUserMessageUpdateEvent';
 
+export type { EventSubAutoModLevel } from './events/common/EventSubAutoModLevel';
+export type { EventSubAutoModResolutionStatus } from './events/common/EventSubAutoModResolutionStatus';
 export { EventSubChannelCharityAmount } from './events/common/EventSubChannelCharityAmount';
 export type { EventSubChannelGoalType } from './events/common/EventSubChannelGoalType';
 export { EventSubChannelHypeTrainContribution } from './events/common/EventSubChannelHypeTrainContribution';

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -66,11 +66,11 @@ export type { EventSubChannelUnbanRequestStatus } from './events/EventSubChannel
 export { EventSubChannelUnbanRequestResolveEvent } from './events/EventSubChannelUnbanRequestResolveEvent';
 export { EventSubAutoModMessageHoldEvent } from './events/EventSubAutoModMessageHoldEvent';
 export { EventSubAutoModMessageUpdateEvent } from './events/EventSubAutoModMessageUpdateEvent';
-export type { EventSubAutoModSettingsUpdateEvent } from './events/EventSubAutoModSettingsUpdateEvent';
-export type { EventSubAutoModTermsUpdateEvent } from './events/EventSubAutoModTermsUpdateEvent';
+export { EventSubAutoModSettingsUpdateEvent } from './events/EventSubAutoModSettingsUpdateEvent';
+export { EventSubAutoModTermsUpdateEvent } from './events/EventSubAutoModTermsUpdateEvent';
 export type { EventSubAutoModTermsUpdateAction } from './events/EventSubAutoModTermsUpdateEvent.external';
-export type { EventSubChannelChatUserMessageHoldEvent } from './events/EventSubChannelChatUserMessageHoldEvent';
-export type { EventSubChannelChatUserMessageUpdateEvent } from './events/EventSubChannelChatUserMessageUpdateEvent';
+export { EventSubChannelChatUserMessageHoldEvent } from './events/EventSubChannelChatUserMessageHoldEvent';
+export { EventSubChannelChatUserMessageUpdateEvent } from './events/EventSubChannelChatUserMessageUpdateEvent';
 
 export type { EventSubAutoModLevel } from './events/common/EventSubAutoModLevel';
 export type { EventSubAutoModResolutionStatus } from './events/common/EventSubAutoModResolutionStatus';

--- a/packages/eventsub-base/src/subscriptions/EventSubAutoModMessageHoldSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubAutoModMessageHoldSubscription.ts
@@ -1,0 +1,44 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubAutoModMessageHoldEvent } from '../events/EventSubAutoModMessageHoldEvent';
+import { type EventSubAutoModMessageHoldEventData } from '../events/EventSubAutoModMessageHoldEvent.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubAutoModMessageHoldSubscription extends EventSubSubscription<EventSubAutoModMessageHoldEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubAutoModMessageHoldEvent) => void,
+		client: EventSubBase,
+		private readonly _broadcasterId: string,
+		private readonly _moderatorId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `automod.message.hold.${this._broadcasterId}.${this._moderatorId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._moderatorId;
+	}
+
+	protected transformData(data: EventSubAutoModMessageHoldEventData): EventSubAutoModMessageHoldEvent {
+		return new EventSubAutoModMessageHoldEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.asUser(
+			this._moderatorId,
+			async ctx =>
+				await ctx.eventSub.subscribeToAutoModMessageHoldEvents(
+					this._broadcasterId,
+					await this._getTransportOptions(),
+				),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubAutoModMessageUpdateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubAutoModMessageUpdateSubscription.ts
@@ -1,0 +1,44 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubAutoModMessageUpdateEvent } from '../events/EventSubAutoModMessageUpdateEvent';
+import { type EventSubAutoModMessageUpdateEventData } from '../events/EventSubAutoModMessageUpdateEvent.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubAutoModMessageUpdateSubscription extends EventSubSubscription<EventSubAutoModMessageUpdateEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubAutoModMessageUpdateEvent) => void,
+		client: EventSubBase,
+		private readonly _broadcasterId: string,
+		private readonly _moderatorId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `automod.message.update.${this._broadcasterId}.${this._moderatorId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._moderatorId;
+	}
+
+	protected transformData(data: EventSubAutoModMessageUpdateEventData): EventSubAutoModMessageUpdateEvent {
+		return new EventSubAutoModMessageUpdateEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.asUser(
+			this._moderatorId,
+			async ctx =>
+				await ctx.eventSub.subscribeToAutoModMessageUpdateEvents(
+					this._broadcasterId,
+					await this._getTransportOptions(),
+				),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubAutoModSettingsUpdateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubAutoModSettingsUpdateSubscription.ts
@@ -1,0 +1,44 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubAutoModSettingsUpdateEvent } from '../events/EventSubAutoModSettingsUpdateEvent';
+import { type EventSubAutoModSettingsUpdateEventData } from '../events/EventSubAutoModSettingsUpdateEvent.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubAutoModSettingsUpdateSubscription extends EventSubSubscription<EventSubAutoModSettingsUpdateEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubAutoModSettingsUpdateEvent) => void,
+		client: EventSubBase,
+		private readonly _broadcasterId: string,
+		private readonly _moderatorId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `automod.settings.update.${this._broadcasterId}.${this._moderatorId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._moderatorId;
+	}
+
+	protected transformData(data: EventSubAutoModSettingsUpdateEventData): EventSubAutoModSettingsUpdateEvent {
+		return new EventSubAutoModSettingsUpdateEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.asUser(
+			this._moderatorId,
+			async ctx =>
+				await ctx.eventSub.subscribeToAutoModSettingsUpdateEvents(
+					this._broadcasterId,
+					await this._getTransportOptions(),
+				),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubAutoModTermsUpdateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubAutoModTermsUpdateSubscription.ts
@@ -1,0 +1,44 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubAutoModTermsUpdateEvent } from '../events/EventSubAutoModTermsUpdateEvent';
+import { type EventSubAutoModTermsUpdateEventData } from '../events/EventSubAutoModTermsUpdateEvent.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubAutoModTermsUpdateSubscription extends EventSubSubscription<EventSubAutoModTermsUpdateEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubAutoModTermsUpdateEvent) => void,
+		client: EventSubBase,
+		private readonly _broadcasterId: string,
+		private readonly _moderatorId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `automod.terms.update.${this._broadcasterId}.${this._moderatorId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._moderatorId;
+	}
+
+	protected transformData(data: EventSubAutoModTermsUpdateEventData): EventSubAutoModTermsUpdateEvent {
+		return new EventSubAutoModTermsUpdateEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.asUser(
+			this._moderatorId,
+			async ctx =>
+				await ctx.eventSub.subscribeToAutoModTermsUpdateEvents(
+					this._broadcasterId,
+					await this._getTransportOptions(),
+				),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatUserMessageHoldSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatUserMessageHoldSubscription.ts
@@ -1,0 +1,46 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubChannelChatUserMessageHoldEvent } from '../events/EventSubChannelChatUserMessageHoldEvent';
+import { type EventSubChannelChatUserMessageHoldEventData } from '../events/EventSubChannelChatUserMessageHoldEvent.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelChatUserMessageHoldSubscription extends EventSubSubscription<EventSubChannelChatUserMessageHoldEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubChannelChatUserMessageHoldEvent) => void,
+		client: EventSubBase,
+		private readonly _broadcasterId: string,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.chat.user_message_hold.${this._broadcasterId}.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelChatUserMessageHoldEventData,
+	): EventSubChannelChatUserMessageHoldEvent {
+		return new EventSubChannelChatUserMessageHoldEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.asUser(
+			this._userId,
+			async ctx =>
+				await ctx.eventSub.subscribeToChannelChatUserMessageHoldEvents(
+					this._broadcasterId,
+					await this._getTransportOptions(),
+				),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatUserMessageUpdateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatUserMessageUpdateSubscription.ts
@@ -1,0 +1,46 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubChannelChatUserMessageUpdateEvent } from '../events/EventSubChannelChatUserMessageUpdateEvent';
+import { type EventSubChannelChatUserMessageUpdateEventData } from '../events/EventSubChannelChatUserMessageUpdateEvent.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelChatUserMessageUpdateSubscription extends EventSubSubscription<EventSubChannelChatUserMessageUpdateEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubChannelChatUserMessageUpdateEvent) => void,
+		client: EventSubBase,
+		private readonly _broadcasterId: string,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.chat.user_message_update.${this._broadcasterId}.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelChatUserMessageUpdateEventData,
+	): EventSubChannelChatUserMessageUpdateEvent {
+		return new EventSubChannelChatUserMessageUpdateEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.asUser(
+			this._userId,
+			async ctx =>
+				await ctx.eventSub.subscribeToChannelChatUserMessageUpdateEvents(
+					this._broadcasterId,
+					await this._getTransportOptions(),
+				),
+		);
+	}
+}


### PR DESCRIPTION
Type: Feature
Fixes: #569 

Implemented subscription types:
- [automod.message.hold](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#automodmessagehold)
- [automod.message.update](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#automodmessageupdate)
- [automod.settings.update](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#automodsettingsupdate)
- [automod.terms.update](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#automodtermsupdate)
- [channel.chat.user_message_hold](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatuser_message_hold)
- [channel.chat.user_message_update](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatuser_message_update)

Tested this manually using `yalc`. 

Ignore discrepancies with the documentation. As is often the case on Twitch, the documentation doesn't match the actual payload.
