### PR TITLE
fix(eventsub): fix incorrect auth for unban requests subscription types

### DIFF
--- a/docs/getting-data/index.md
+++ b/docs/getting-data/index.md
@@ -74,5 +74,6 @@ should use for which use case.
 | Drops                                  | No                           | No                        | Yes                        |
 | Charity campaigns & donations          | No                           | No                        | Yes                        |
 | Shield mode begin/end                  | No                           | No                        | Yes                        |
-| Unban request approve/deny             | No                           | Yes                       | No (in beta by Twitch)     |
+| Unban request create                   | No                           | No                        | Yes                        |
+| Unban request resolve                  | No                           | Yes                       | Yes                        |
 | Low-trust users treatment/chat message | No                           | Yes                       | No (in beta by Twitch)     |

--- a/packages/eventsub-base/src/events/EventSubChannelUnbanRequestCreateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelUnbanRequestCreateEvent.ts
@@ -4,7 +4,7 @@ import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurpl
 import { type EventSubChannelUnbanRequestCreateEventData } from './EventSubChannelUnbanRequestCreateEvent.external';
 
 /**
- * An EventSub event representing a broadcaster shouting out another broadcaster.
+ * An EventSub event representing an unban request in a channel.
  */
 @rtfm<EventSubChannelUnbanRequestCreateEvent>('eventsub-base', 'EventSubChannelUnbanRequestCreateEvent', 'id')
 export class EventSubChannelUnbanRequestCreateEvent extends DataObject<EventSubChannelUnbanRequestCreateEventData> {
@@ -24,28 +24,28 @@ export class EventSubChannelUnbanRequestCreateEvent extends DataObject<EventSubC
 	}
 
 	/**
-	 * The ID of the broadcaster the unban request was created for.
+	 * The ID of the broadcaster in which channel the unban request was created.
 	 */
 	get broadcasterId(): string {
 		return this[rawDataSymbol].broadcaster_user_id;
 	}
 
 	/**
-	 * The name of the broadcaster the unban request was created for.
+	 * The name of the broadcaster in which channel the unban request was created.
 	 */
 	get broadcasterName(): string {
 		return this[rawDataSymbol].broadcaster_user_login;
 	}
 
 	/**
-	 * The display name of the broadcaster the unban request was created for.
+	 * The display name of the broadcaster in which channel the unban request was created.
 	 */
 	get broadcasterDisplayName(): string {
 		return this[rawDataSymbol].broadcaster_user_name;
 	}
 
 	/**
-	 * Gets more information about the broadcaster in which channel the unban request was created for.
+	 * Gets more information about the broadcaster in which channel the unban request was created.
 	 */
 	async getBroadcaster(): Promise<HelixUser> {
 		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));

--- a/packages/eventsub-base/src/events/EventSubChannelUnbanRequestResolveEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelUnbanRequestResolveEvent.ts
@@ -7,7 +7,7 @@ import {
 } from './EventSubChannelUnbanRequestResolveEvent.external';
 
 /**
- * An EventSub event representing an unban request in a channel.
+ * An EventSub event representing the resolution of an unban request in a channel.
  */
 @rtfm<EventSubChannelUnbanRequestResolveEvent>('eventsub-base', 'EventSubChannelUnbanRequestResolveEvent', 'id')
 export class EventSubChannelUnbanRequestResolveEvent extends DataObject<EventSubChannelUnbanRequestResolveEventData> {
@@ -111,7 +111,7 @@ export class EventSubChannelUnbanRequestResolveEvent extends DataObject<EventSub
 	}
 
 	/**
-	 * Resolution text supplied by the mod/broadcaster upon approval/denial of the request.
+	 * The message supplied by the mod/broadcaster upon resolution of the request.
 	 */
 	get resolutionMessage(): string | null {
 		return this[rawDataSymbol].resolution_text ?? null;

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestCreateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestCreateSubscription.ts
@@ -13,18 +13,18 @@ export class EventSubChannelUnbanRequestCreateSubscription extends EventSubSubsc
 	constructor(
 		handler: (data: EventSubChannelUnbanRequestCreateEvent) => void,
 		client: EventSubBase,
-		private readonly _userId: string,
+		private readonly _broadcasterId: string,
 		private readonly _moderatorId: string,
 	) {
 		super(handler, client);
 	}
 
 	get id(): string {
-		return `channel.unban_request.create.${this._userId}`;
+		return `channel.unban_request.create.${this._broadcasterId}`;
 	}
 
 	get authUserId(): string | null {
-		return this._userId;
+		return this._moderatorId;
 	}
 
 	protected transformData(data: EventSubChannelUnbanRequestCreateEventData): EventSubChannelUnbanRequestCreateEvent {
@@ -36,7 +36,7 @@ export class EventSubChannelUnbanRequestCreateSubscription extends EventSubSubsc
 			this._moderatorId,
 			async ctx =>
 				await ctx.eventSub.subscribeToChannelUnbanRequestCreateEvents(
-					this._userId,
+					this._broadcasterId,
 					await this._getTransportOptions(),
 				),
 		);

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestCreateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestCreateSubscription.ts
@@ -20,7 +20,7 @@ export class EventSubChannelUnbanRequestCreateSubscription extends EventSubSubsc
 	}
 
 	get id(): string {
-		return `channel.unban_request.create.${this._broadcasterId}`;
+		return `channel.unban_request.create.${this._broadcasterId}.${this._moderatorId}`;
 	}
 
 	get authUserId(): string | null {

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestResolveSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestResolveSubscription.ts
@@ -20,7 +20,7 @@ export class EventSubChannelUnbanRequestResolveSubscription extends EventSubSubs
 	}
 
 	get id(): string {
-		return `channel.unban_request.resolve.${this._broadcasterId}`;
+		return `channel.unban_request.resolve.${this._broadcasterId}.${this._moderatorId}`;
 	}
 
 	get authUserId(): string | null {

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestResolveSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelUnbanRequestResolveSubscription.ts
@@ -13,18 +13,18 @@ export class EventSubChannelUnbanRequestResolveSubscription extends EventSubSubs
 	constructor(
 		handler: (data: EventSubChannelUnbanRequestResolveEvent) => void,
 		client: EventSubBase,
-		private readonly _userId: string,
+		private readonly _broadcasterId: string,
 		private readonly _moderatorId: string,
 	) {
 		super(handler, client);
 	}
 
 	get id(): string {
-		return `channel.unban_request.resolve.${this._userId}`;
+		return `channel.unban_request.resolve.${this._broadcasterId}`;
 	}
 
 	get authUserId(): string | null {
-		return this._userId;
+		return this._moderatorId;
 	}
 
 	protected transformData(
@@ -38,7 +38,7 @@ export class EventSubChannelUnbanRequestResolveSubscription extends EventSubSubs
 			this._moderatorId,
 			async ctx =>
 				await ctx.eventSub.subscribeToChannelUnbanRequestResolveEvents(
-					this._userId,
+					this._broadcasterId,
 					await this._getTransportOptions(),
 				),
 		);


### PR DESCRIPTION
Type: Bugfix
Fixes: -

- Fixed incorrect `authUserId` field in unban requests subscription types. The subscriptions now correctly use moderator's tokens (tested using `yalc`).
- Fixed ID pattern in unban requests subscription types. The subscription IDs now include the moderator's ID.
- Fix/improve docs