### PR TITLE
fix export of EventSubChannelAdBreakBeginEvent

### DIFF
--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -6,6 +6,7 @@ export type {
 	EventSubRevocationPayload,
 } from './EventSubPayload.external';
 
+export { EventSubChannelAdBreakBeginEvent } from './events/EventSubChannelAdBreakBeginEvent';
 export { EventSubChannelBanEvent } from './events/EventSubChannelBanEvent';
 export { EventSubChannelCharityCampaignProgressEvent } from './events/EventSubChannelCharityCampaignProgressEvent';
 export { EventSubChannelCharityCampaignStartEvent } from './events/EventSubChannelCharityCampaignStartEvent';


### PR DESCRIPTION
Type: Bugfix
Fixes: #594

Fixed the EventSubChannelAdBreakBeginEvent type not being exported