### PR TITLE
Feat: EventSub Suspicious User Events

### DIFF
--- a/docs/getting-data/index.md
+++ b/docs/getting-data/index.md
@@ -54,30 +54,30 @@ should use for which use case.
 
 ## Events
 
-| Event type                             | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub-*`  |
-|----------------------------------------|------------------------------|---------------------------|------------------------|
-| Chat messages                          | Yes                          | Sub & cheer messages only | Yes                    |
-| Chat mode (e.g. sub only) changes      | Yes                          | No                        | Yes                    |
-| Whispers                               | Yes                          | Yes                       | Yes                    |
-| Cheers                                 | Yes                          | Yes                       | Yes                    |
-| Channel points                         | Redemptions w/ messages only | Redemptions only          | Yes                    |
-| Subscriptions                          | Published only               | Published only            | Yes                    |
-| AutoMod                                | No                           | Yes                       | Yes                    |
-| Live / offline / stream changes        | No                           | No                        | Yes                    |
-| Follows                                | No                           | No                        | Yes                    |
-| Raids                                  | Yes                          | No                        | Yes                    |
-| Bans                                   | Yes                          | Yes                       | Yes                    |
-| Mod add/remove                         | No                           | Yes                       | Yes                    |
-| VIP add/remove                         | No                           | No                        | Yes                    |
-| Polls & predictions                    | No                           | No                        | Yes                    |
-| Extension transactions                 | No                           | No                        | Yes                    |
-| Hype Trains                            | No                           | No                        | Yes                    |
-| Authorization grant/revoke             | No                           | No                        | Yes                    |
-| Drops                                  | No                           | No                        | Yes                    |
-| Charity campaigns & donations          | No                           | No                        | Yes                    |
-| Shield mode begin/end                  | No                           | No                        | Yes                    |
-| Unban request create                   | No                           | No                        | Yes                    |
-| Unban request resolve                  | No                           | Yes                       | Yes                    |
-| Low-trust users treatment/chat message | No                           | Yes                       | No (in beta by Twitch) |
-| Warnings                               | No                           | No                        | Yes                    |
-| Moderation actions                     | No                           | Yes                       | Yes                    |
+| Event type                                  | `@twurple/chat`              | `@twurple/pubsub`         | `@twurple/eventsub-*` |
+|---------------------------------------------|------------------------------|---------------------------|-----------------------|
+| Chat messages                               | Yes                          | Sub & cheer messages only | Yes                   |
+| Chat mode (e.g. sub only) changes           | Yes                          | No                        | Yes                   |
+| Whispers                                    | Yes                          | Yes                       | Yes                   |
+| Cheers                                      | Yes                          | Yes                       | Yes                   |
+| Channel points                              | Redemptions w/ messages only | Redemptions only          | Yes                   |
+| Subscriptions                               | Published only               | Published only            | Yes                   |
+| AutoMod                                     | No                           | Yes                       | Yes                   |
+| Live / offline / stream changes             | No                           | No                        | Yes                   |
+| Follows                                     | No                           | No                        | Yes                   |
+| Raids                                       | Yes                          | No                        | Yes                   |
+| Bans                                        | Yes                          | Yes                       | Yes                   |
+| Mod add/remove                              | No                           | Yes                       | Yes                   |
+| VIP add/remove                              | No                           | No                        | Yes                   |
+| Polls & predictions                         | No                           | No                        | Yes                   |
+| Extension transactions                      | No                           | No                        | Yes                   |
+| Hype Trains                                 | No                           | No                        | Yes                   |
+| Authorization grant/revoke                  | No                           | No                        | Yes                   |
+| Drops                                       | No                           | No                        | Yes                   |
+| Charity campaigns & donations               | No                           | No                        | Yes                   |
+| Shield mode begin/end                       | No                           | No                        | Yes                   |
+| Unban request create                        | No                           | No                        | Yes                   |
+| Unban request resolve                       | No                           | Yes                       | Yes                   |
+| Suspicious (low-trust) users update/message | No                           | Yes                       | Yes                   |
+| Warnings                                    | No                           | No                        | Yes                   |
+| Moderation actions                          | No                           | Yes                       | Yes                   |

--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -1791,6 +1791,50 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribes to events that represent a suspicious user updated in a channel.
+	 *
+	 * @param broadcaster The broadcaster you want to listen for suspicious user update events.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelSuspiciousUserUpdateEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.suspicious_user.update',
+			'1',
+			createEventSubModeratorCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['moderator:read:suspicious_users'],
+			true,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a message sent by a suspicious user.
+	 *
+	 * @param broadcaster The broadcaster you want to listen for messages sent by suspicious users.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelSuspiciousUserMessageEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.suspicious_user.message',
+			'1',
+			createEventSubModeratorCondition(broadcasterId, this._getUserContextIdWithDefault(broadcasterId)),
+			transport,
+			broadcaster,
+			['moderator:read:suspicious_users'],
+			true,
+		);
+	}
+
+	/**
 	 * Gets the current EventSub conduits for the current client.
 	 *
 	 */

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -59,6 +59,8 @@ import type { EventSubChannelSubscriptionEndEvent } from './events/EventSubChann
 import type { EventSubChannelSubscriptionEvent } from './events/EventSubChannelSubscriptionEvent';
 import type { EventSubChannelSubscriptionGiftEvent } from './events/EventSubChannelSubscriptionGiftEvent';
 import type { EventSubChannelSubscriptionMessageEvent } from './events/EventSubChannelSubscriptionMessageEvent';
+import type { EventSubChannelSuspiciousUserUpdateEvent } from './events/EventSubChannelSuspiciousUserUpdateEvent';
+import type { EventSubChannelSuspiciousUserMessageEvent } from './events/EventSubChannelSuspiciousUserMessageEvent';
 import type { EventSubChannelUnbanEvent } from './events/EventSubChannelUnbanEvent';
 import { type EventSubChannelUnbanRequestCreateEvent } from './events/EventSubChannelUnbanRequestCreateEvent';
 import { type EventSubChannelUnbanRequestResolveEvent } from './events/EventSubChannelUnbanRequestResolveEvent';
@@ -125,6 +127,8 @@ import { EventSubChannelSubscriptionEndSubscription } from './subscriptions/Even
 import { EventSubChannelSubscriptionGiftSubscription } from './subscriptions/EventSubChannelSubscriptionGiftSubscription';
 import { EventSubChannelSubscriptionMessageSubscription } from './subscriptions/EventSubChannelSubscriptionMessageSubscription';
 import { EventSubChannelSubscriptionSubscription } from './subscriptions/EventSubChannelSubscriptionSubscription';
+import { EventSubChannelSuspiciousUserUpdateSubscription } from './subscriptions/EventSubChannelSuspiciousUserUpdateSubscription';
+import { EventSubChannelSuspiciousUserMessageSubscription } from './subscriptions/EventSubChannelSuspiciousUserMessageSubscription';
 import { EventSubChannelUnbanRequestCreateSubscription } from './subscriptions/EventSubChannelUnbanRequestCreateSubscription';
 import { EventSubChannelUnbanRequestResolveSubscription } from './subscriptions/EventSubChannelUnbanRequestResolveSubscription';
 import { EventSubChannelUnbanSubscription } from './subscriptions/EventSubChannelUnbanSubscription';
@@ -1328,6 +1332,54 @@ export abstract class EventSubBase extends EventEmitter {
 		const userId = this._extractUserIdWithNumericWarning(user, 'onChannelVipRemove');
 
 		return this._genericSubscribe(EventSubChannelVipRemoveSubscription, handler, this, userId);
+	}
+
+	/**
+	 * Subscribes to events that represent a suspicious user updated in a channel.
+	 *
+	 * @param broadcaster The user for which to get notifications about suspicious user updated in their channel.
+	 * @param moderator A user that has permission to read suspicious users in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelSuspiciousUserUpdate(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (event: EventSubChannelSuspiciousUserUpdateEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelSuspiciousUserUpdate');
+		const moderatorId = this._extractUserIdWithNumericWarning(moderator, 'onChannelSuspiciousUserUpdate');
+
+		return this._genericSubscribe(
+			EventSubChannelSuspiciousUserUpdateSubscription,
+			handler,
+			this,
+			broadcasterId,
+			moderatorId,
+		);
+	}
+
+	/**
+	 * Subscribes to events that represent a message sent by a suspicious user.
+	 *
+	 * @param broadcaster The user for which to get notifications about messages sent by suspicious users.
+	 * @param moderator A user that has permission to read suspicious users in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelSuspiciousUserMessage(
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (event: EventSubChannelSuspiciousUserMessageEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelSuspiciousUserMessage');
+		const moderatorId = this._extractUserIdWithNumericWarning(moderator, 'onChannelSuspiciousUserMessage');
+
+		return this._genericSubscribe(
+			EventSubChannelSuspiciousUserMessageSubscription,
+			handler,
+			this,
+			broadcasterId,
+			moderatorId,
+		);
 	}
 
 	/**

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -48,6 +48,8 @@ import type { EventSubChannelSubscriptionEndEvent } from './events/EventSubChann
 import type { EventSubChannelSubscriptionEvent } from './events/EventSubChannelSubscriptionEvent';
 import type { EventSubChannelSubscriptionGiftEvent } from './events/EventSubChannelSubscriptionGiftEvent';
 import type { EventSubChannelSubscriptionMessageEvent } from './events/EventSubChannelSubscriptionMessageEvent';
+import type { EventSubChannelSuspiciousUserUpdateEvent } from './events/EventSubChannelSuspiciousUserUpdateEvent';
+import type { EventSubChannelSuspiciousUserMessageEvent } from './events/EventSubChannelSuspiciousUserMessageEvent';
 import type { EventSubChannelUnbanEvent } from './events/EventSubChannelUnbanEvent';
 import { type EventSubChannelUnbanRequestCreateEvent } from './events/EventSubChannelUnbanRequestCreateEvent';
 import { type EventSubChannelUnbanRequestResolveEvent } from './events/EventSubChannelUnbanRequestResolveEvent';
@@ -786,6 +788,32 @@ export interface EventSubListener {
 		broadcaster: UserIdResolvable,
 		moderator: UserIdResolvable,
 		handler: (data: EventSubChannelWarningSendEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a suspicious user updated in a channel.
+	 *
+	 * @param broadcaster The user for which to get notifications about suspicious user updated in their channel.
+	 * @param moderator A user that has permission to read suspicious users in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelSuspiciousUserUpdate: (
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (event: EventSubChannelSuspiciousUserUpdateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a message sent by a suspicious user.
+	 *
+	 * @param broadcaster The user for which to get notifications about messages sent by suspicious users.
+	 * @param moderator A user that has permission to read suspicious users in the broadcaster's channel.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelSuspiciousUserMessage: (
+		broadcaster: UserIdResolvable,
+		moderator: UserIdResolvable,
+		handler: (event: EventSubChannelSuspiciousUserMessageEvent) => void,
 	) => EventSubSubscription;
 
 	/**

--- a/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserMessageEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserMessageEvent.external.ts
@@ -3,7 +3,7 @@ import { type EventSubChannelSuspiciousUserLowTrustStatus } from './common/Event
 /**
  * User types (if any) that apply to the suspicious user.
  */
-export type EventSubChannelSuspiciousUserType = 'manually_added' | 'ban_evader' | 'shared_channel_ban';
+export type EventSubChannelSuspiciousUserType = 'manually_added' | 'ban_evader' | 'banned_in_shared_channel';
 
 /**
  * A ban evasion likelihood value (if any) that as been applied to the user automatically by Twitch.

--- a/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserMessageEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserMessageEvent.external.ts
@@ -1,0 +1,72 @@
+import { type EventSubChannelSuspiciousUserLowTrustStatus } from './common/EventSubChannelSuspiciousUserLowTrustStatus';
+
+/**
+ * User types (if any) that apply to the suspicious user.
+ */
+export type EventSubChannelSuspiciousUserType = 'manually_added' | 'ban_evader' | 'shared_channel_ban';
+
+/**
+ * A ban evasion likelihood value (if any) that as been applied to the user automatically by Twitch.
+ */
+export type EventSubChannelBanEvasionEvaluation = 'possible' | 'likely' | 'unknown';
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageTextPart {
+	type: 'text';
+	text: string;
+}
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageEmoteData {
+	id: string;
+	emote_set_id: string;
+}
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageEmotePart {
+	type: 'emote';
+	text: string;
+	emote: EventSubChannelSuspiciousUserMessageEmoteData;
+}
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageCheermoteData {
+	prefix: string;
+	bits: number;
+	tier: number;
+}
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageCheermotePart {
+	type: 'cheermote';
+	text: string;
+	cheermote: EventSubChannelSuspiciousUserMessageCheermoteData;
+}
+
+/** @private */
+export type EventSubChannelSuspiciousUserMessagePart =
+	| EventSubChannelSuspiciousUserMessageTextPart
+	| EventSubChannelSuspiciousUserMessageEmotePart
+	| EventSubChannelSuspiciousUserMessageCheermotePart;
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageData {
+	message_id: string;
+	text: string;
+	fragments: EventSubChannelSuspiciousUserMessagePart[];
+}
+
+/** @private */
+export interface EventSubChannelSuspiciousUserMessageEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_name: string;
+	broadcaster_user_login: string;
+	user_id: string;
+	user_name: string;
+	user_login: string;
+	low_trust_status: EventSubChannelSuspiciousUserLowTrustStatus;
+	shared_ban_channel_ids: string[] | null;
+	types: EventSubChannelSuspiciousUserType[];
+	ban_evasion_evaluation: EventSubChannelBanEvasionEvaluation;
+	message: EventSubChannelSuspiciousUserMessageData;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserMessageEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserMessageEvent.ts
@@ -1,0 +1,133 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import type { EventSubChannelSuspiciousUserLowTrustStatus } from './common/EventSubChannelSuspiciousUserLowTrustStatus';
+import {
+	type EventSubChannelBanEvasionEvaluation,
+	type EventSubChannelSuspiciousUserType,
+	type EventSubChannelSuspiciousUserMessageEventData,
+	type EventSubChannelSuspiciousUserMessagePart,
+} from './EventSubChannelSuspiciousUserMessageEvent.external';
+
+/**
+ * An EventSub event representing a message sent by a suspicious user in a channel.
+ */
+@rtfm<EventSubChannelSuspiciousUserMessageEvent>(
+	'eventsub-base',
+	'EventSubChannelSuspiciousUserMessageEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSuspiciousUserMessageEvent extends DataObject<EventSubChannelSuspiciousUserMessageEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelSuspiciousUserMessageEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the channel in which a suspicious user sent the message.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the channel in which a suspicious user sent the message.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the channel in which a suspicious user sent the message.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the user who sent the message.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the user who sent the message.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the user who sent the message.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the user whose treatment was updated.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * The status set for the suspicious user.
+	 */
+	get lowTrustStatus(): EventSubChannelSuspiciousUserLowTrustStatus {
+		return this[rawDataSymbol].low_trust_status;
+	}
+
+	/**
+	 * A list of channel IDs where the suspicious user is also banned.
+	 */
+	get sharedBanChannelIds(): string[] {
+		return this[rawDataSymbol].shared_ban_channel_ids ?? [];
+	}
+
+	/**
+	 * User types (if any) that apply to the suspicious user.
+	 */
+	get types(): EventSubChannelSuspiciousUserType[] {
+		return this[rawDataSymbol].types;
+	}
+
+	/**
+	 * A ban evasion likelihood value (if any) that as been applied to the user automatically by Twitch.
+	 */
+	get banEvasionEvaluation(): EventSubChannelBanEvasionEvaluation {
+		return this[rawDataSymbol].ban_evasion_evaluation;
+	}
+
+	/**
+	 * The UUID that identifies the message.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].message.message_id;
+	}
+
+	/**
+	 * The chat message in plain text.
+	 */
+	get messageText(): string {
+		return this[rawDataSymbol].message.text;
+	}
+
+	/**
+	 * Ordered list of chat message fragments.
+	 */
+	get messageParts(): EventSubChannelSuspiciousUserMessagePart[] {
+		return this[rawDataSymbol].message.fragments;
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserUpdateEvent.external.ts
@@ -1,0 +1,15 @@
+import { type EventSubChannelSuspiciousUserLowTrustStatus } from './common/EventSubChannelSuspiciousUserLowTrustStatus';
+
+/** @private */
+export interface EventSubChannelSuspiciousUserUpdateEventData {
+	broadcaster_user_id: string;
+	broadcaster_user_name: string;
+	broadcaster_user_login: string;
+	moderator_user_id: string;
+	moderator_user_name: string;
+	moderator_user_login: string;
+	user_id: string;
+	user_name: string;
+	user_login: string;
+	low_trust_status: EventSubChannelSuspiciousUserLowTrustStatus;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSuspiciousUserUpdateEvent.ts
@@ -1,0 +1,114 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type EventSubChannelSuspiciousUserUpdateEventData } from './EventSubChannelSuspiciousUserUpdateEvent.external';
+import type { EventSubChannelSuspiciousUserLowTrustStatus } from './common/EventSubChannelSuspiciousUserLowTrustStatus';
+
+/**
+ * An EventSub event representing a suspicious user being updated in a channel.
+ */
+@rtfm<EventSubChannelSuspiciousUserUpdateEvent>(
+	'eventsub-base',
+	'EventSubChannelSuspiciousUserUpdateEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSuspiciousUserUpdateEvent extends DataObject<EventSubChannelSuspiciousUserUpdateEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelSuspiciousUserUpdateEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the channel where the treatment for a suspicious user was updated.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the channel where the treatment for a suspicious user was updated.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the channel where the treatment for a suspicious user was updated.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the moderator that updated the treatment for a suspicious user.
+	 */
+	get moderatorId(): string {
+		return this[rawDataSymbol].moderator_user_id;
+	}
+
+	/**
+	 * The name of the moderator that updated the treatment for a suspicious user.
+	 */
+	get moderatorName(): string {
+		return this[rawDataSymbol].moderator_user_login;
+	}
+
+	/**
+	 * The display name of the moderator that updated the treatment for a suspicious user.
+	 */
+	get moderatorDisplayName(): string {
+		return this[rawDataSymbol].moderator_user_name;
+	}
+
+	/**
+	 * Gets more information about the moderator.
+	 */
+	async getModerator(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].moderator_user_id));
+	}
+
+	/**
+	 * The ID of the suspicious user whose treatment was updated.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the suspicious user whose treatment was updated.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the suspicious user whose treatment was updated.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the user whose treatment was updated.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * The status set for the suspicious user.
+	 */
+	get lowTrustStatus(): EventSubChannelSuspiciousUserLowTrustStatus {
+		return this[rawDataSymbol].low_trust_status;
+	}
+}

--- a/packages/eventsub-base/src/events/common/EventSubChannelSuspiciousUserLowTrustStatus.ts
+++ b/packages/eventsub-base/src/events/common/EventSubChannelSuspiciousUserLowTrustStatus.ts
@@ -1,0 +1,4 @@
+/**
+ * The status set for the suspicious user.
+ */
+export type EventSubChannelSuspiciousUserLowTrustStatus = 'no_treatment' | 'active_monitoring' | 'restricted';

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -110,6 +110,12 @@ export { EventSubChannelChatUserMessageHoldEvent } from './events/EventSubChanne
 export { EventSubChannelChatUserMessageUpdateEvent } from './events/EventSubChannelChatUserMessageUpdateEvent';
 export { EventSubChannelWarningAcknowledgeEvent } from './events/EventSubChannelWarningAcknowledgeEvent';
 export { EventSubChannelWarningSendEvent } from './events/EventSubChannelWarningSendEvent';
+export { EventSubChannelSuspiciousUserUpdateEvent } from './events/EventSubChannelSuspiciousUserUpdateEvent';
+export { EventSubChannelSuspiciousUserMessageEvent } from './events/EventSubChannelSuspiciousUserMessageEvent';
+export type {
+	EventSubChannelBanEvasionEvaluation,
+	EventSubChannelSuspiciousUserType,
+} from './events/EventSubChannelSuspiciousUserMessageEvent.external';
 
 export type { EventSubAutoModLevel } from './events/common/EventSubAutoModLevel';
 export type { EventSubAutoModResolutionStatus } from './events/common/EventSubAutoModResolutionStatus';
@@ -123,5 +129,6 @@ export { EventSubChannelPredictionBeginOutcome } from './events/common/EventSubC
 export type { EventSubChannelPredictionColor } from './events/common/EventSubChannelPredictionBeginOutcome.external';
 export { EventSubChannelPredictionOutcome } from './events/common/EventSubChannelPredictionOutcome';
 export { EventSubChannelPredictionPredictor } from './events/common/EventSubChannelPredictionPredictor';
+export type { EventSubChannelSuspiciousUserLowTrustStatus } from './events/common/EventSubChannelSuspiciousUserLowTrustStatus';
 
 export { EventSubSubscription } from './subscriptions/EventSubSubscription';


### PR DESCRIPTION
Type: Feature
Fixes: #576 

Tested using `yalc`. The values ​​in the documentation differ in some places from the actual values ​​that Twitch sends. I tested all possible events and found the correct values for types.

