### PR TITLE
 Feat: Shared chat

### DIFF
--- a/packages/api/src/endpoints/chat/HelixChatApi.ts
+++ b/packages/api/src/endpoints/chat/HelixChatApi.ts
@@ -44,6 +44,11 @@ import { HelixEmoteFromSet } from './HelixEmoteFromSet';
 import { HelixUserEmote } from './HelixUserEmote';
 import { HelixPrivilegedChatSettings } from './HelixPrivilegedChatSettings';
 import { HelixSentChatMessage } from './HelixSentChatMessage';
+import {
+	createSharedChatSessionQuery,
+	type HelixSharedChatSessionData,
+} from '../../interfaces/endpoints/shared-chat-session.external';
+import { HelixSharedChatSession } from './HelixSharedChatSession';
 
 /**
  * The Helix API methods that deal with chat.
@@ -503,6 +508,30 @@ export class HelixChatApi extends BaseApi {
 			scopes: ['moderator:manage:shoutouts'],
 			query: createShoutoutQuery(from, to, this._getUserContextIdWithDefault(fromId)),
 		});
+	}
+
+	/**
+	 * Gets the active shared chat session for a channel.
+	 *
+	 * Returns `null` if there is no active shared chat session in the channel.
+	 *
+	 * @param broadcaster The broadcaster to get the active shared chat session for.
+	 */
+	async getSharedChatSession(broadcaster: UserIdResolvable): Promise<HelixSharedChatSession | null> {
+		const broadcasterId = extractUserId(broadcaster);
+
+		const response = await this._client.callApi<HelixResponse<HelixSharedChatSessionData>>({
+			type: 'helix',
+			url: 'shared_chat/session',
+			userId: broadcasterId,
+			query: createSharedChatSessionQuery(broadcasterId),
+		});
+
+		if (response.data.length === 0) {
+			return null;
+		}
+
+		return new HelixSharedChatSession(response.data[0], this._client);
 	}
 
 	private _createModeratorActionQuery(broadcasterId: string) {

--- a/packages/api/src/endpoints/chat/HelixSharedChatSession.ts
+++ b/packages/api/src/endpoints/chat/HelixSharedChatSession.ts
@@ -1,0 +1,62 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type HelixSharedChatSessionData } from '../../interfaces/endpoints/shared-chat-session.external';
+import { type BaseApiClient } from '../../client/BaseApiClient';
+import { type HelixUser } from '../user/HelixUser';
+import { HelixSharedChatSessionParticipant } from './HelixSharedChatSessionParticipant';
+
+/**
+ * A shared chat session.
+ */
+@rtfm<HelixSharedChatSession>('api', 'HelixSharedChatSession', 'sessionId')
+export class HelixSharedChatSession extends DataObject<HelixSharedChatSessionData> {
+	/** @internal */ @Enumerable(false) private readonly _client: BaseApiClient;
+
+	/** @internal */
+	constructor(data: HelixSharedChatSessionData, client: BaseApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The unique identifier for the shared chat session.
+	 */
+	get sessionId(): string {
+		return this[rawDataSymbol].session_id;
+	}
+
+	/**
+	 * The ID of the host broadcaster.
+	 */
+	get hostBroadcasterId(): string {
+		return this[rawDataSymbol].host_broadcaster_id;
+	}
+
+	/**
+	 * Gets information about the host broadcaster.
+	 */
+	async getHostBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].host_broadcaster_id));
+	}
+
+	/**
+	 * The list of participants in the session.
+	 */
+	get participants(): HelixSharedChatSessionParticipant[] {
+		return this[rawDataSymbol].participants.map(data => new HelixSharedChatSessionParticipant(data, this._client));
+	}
+
+	/**
+	 * The date for when the session was created.
+	 */
+	get createdDate(): Date {
+		return new Date(this[rawDataSymbol].created_at);
+	}
+
+	/**
+	 * The date for when the session was updated.
+	 */
+	get updatedDate(): Date {
+		return new Date(this[rawDataSymbol].updated_at);
+	}
+}

--- a/packages/api/src/endpoints/chat/HelixSharedChatSessionParticipant.ts
+++ b/packages/api/src/endpoints/chat/HelixSharedChatSessionParticipant.ts
@@ -1,0 +1,33 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type HelixSharedChatSessionParticipantData } from '../../interfaces/endpoints/shared-chat-session.external';
+import { type BaseApiClient } from '../../client/BaseApiClient';
+import { type HelixUser } from '../user/HelixUser';
+
+/**
+ * A shared chat session participant.
+ */
+@rtfm<HelixSharedChatSessionParticipant>('api', 'HelixSharedChatSessionParticipant', 'broadcasterId')
+export class HelixSharedChatSessionParticipant extends DataObject<HelixSharedChatSessionParticipantData> {
+	/** @internal */ @Enumerable(false) private readonly _client: BaseApiClient;
+
+	/** @internal */
+	constructor(data: HelixSharedChatSessionParticipantData, client: BaseApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the participant broadcaster.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_id;
+	}
+
+	/**
+	 * Gets information about the participant broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_id));
+	}
+}

--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -1835,6 +1835,66 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribes to events indicating that a shared chat session has begun in a channel.
+	 *
+	 * @param broadcaster The broadcaster for whom shared chat session begin events should be listened to.
+	 * @param transport The transport options to use for the subscription.
+	 */
+	async subscribeToChannelSharedChatSessionBeginEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.shared_chat.begin',
+			'1',
+			createEventSubBroadcasterCondition(broadcasterId),
+			transport,
+			broadcasterId,
+		);
+	}
+
+	/**
+	 * Subscribes to events indicating that a shared chat session has been updated in a channel.
+	 *
+	 * @param broadcaster The broadcaster for whom shared chat session update events should be listened to.
+	 * @param transport The transport options to use for the subscription.
+	 */
+	async subscribeToChannelSharedChatSessionUpdateEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.shared_chat.update',
+			'1',
+			createEventSubBroadcasterCondition(broadcasterId),
+			transport,
+			broadcasterId,
+		);
+	}
+
+	/**
+	 * Subscribes to events indicating that a shared chat session has ended in a channel.
+	 *
+	 * @param broadcaster The broadcaster for whom shared chat session end events should be listened to.
+	 * @param transport The transport options to use for the subscription.
+	 */
+	async subscribeToChannelSharedChatSessionEndEvents(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		const broadcasterId = extractUserId(broadcaster);
+		return await this.createSubscription(
+			'channel.shared_chat.end',
+			'1',
+			createEventSubBroadcasterCondition(broadcasterId),
+			transport,
+			broadcasterId,
+		);
+	}
+
+	/**
 	 * Gets the current EventSub conduits for the current client.
 	 *
 	 */

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -48,6 +48,8 @@ export { HelixEmoteFromSet } from './endpoints/chat/HelixEmoteFromSet';
 export { HelixUserEmote } from './endpoints/chat/HelixUserEmote';
 export { HelixPrivilegedChatSettings } from './endpoints/chat/HelixPrivilegedChatSettings';
 export { HelixSentChatMessage } from './endpoints/chat/HelixSentChatMessage';
+export { HelixSharedChatSessionParticipant } from './endpoints/chat/HelixSharedChatSessionParticipant';
+export { HelixSharedChatSession } from './endpoints/chat/HelixSharedChatSession';
 export type {
 	HelixChannelEmoteSubscriptionTier,
 	HelixEmoteImageScale,

--- a/packages/api/src/interfaces/endpoints/shared-chat-session.external.ts
+++ b/packages/api/src/interfaces/endpoints/shared-chat-session.external.ts
@@ -1,0 +1,22 @@
+import { extractUserId, type UserIdResolvable } from '@twurple/common';
+
+/** @private */
+export interface HelixSharedChatSessionParticipantData {
+	broadcaster_id: string;
+}
+
+/** @private */
+export interface HelixSharedChatSessionData {
+	session_id: string;
+	host_broadcaster_id: string;
+	participants: HelixSharedChatSessionParticipantData[];
+	created_at: string;
+	updated_at: string;
+}
+
+/** @internal */
+export function createSharedChatSessionQuery(broadcaster: UserIdResolvable) {
+	return {
+		broadcaster_id: extractUserId(broadcaster),
+	};
+}

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -51,6 +51,9 @@ import type { EventSubChannelRedemptionAddEvent } from './events/EventSubChannel
 import type { EventSubChannelRedemptionUpdateEvent } from './events/EventSubChannelRedemptionUpdateEvent';
 import type { EventSubChannelRewardEvent } from './events/EventSubChannelRewardEvent';
 import type { EventSubChannelAutomaticRewardRedemptionAddEvent } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent';
+import { type EventSubChannelSharedChatSessionBeginEvent } from './events/EventSubChannelSharedChatSessionBeginEvent';
+import { type EventSubChannelSharedChatSessionUpdateEvent } from './events/EventSubChannelSharedChatSessionUpdateEvent';
+import { type EventSubChannelSharedChatSessionEndEvent } from './events/EventSubChannelSharedChatSessionEndEvent';
 import type { EventSubChannelShieldModeBeginEvent } from './events/EventSubChannelShieldModeBeginEvent';
 import type { EventSubChannelShieldModeEndEvent } from './events/EventSubChannelShieldModeEndEvent';
 import type { EventSubChannelShoutoutCreateEvent } from './events/EventSubChannelShoutoutCreateEvent';
@@ -119,6 +122,9 @@ import { EventSubChannelRewardAddSubscription } from './subscriptions/EventSubCh
 import { EventSubChannelRewardRemoveSubscription } from './subscriptions/EventSubChannelRewardRemoveSubscription';
 import { EventSubChannelRewardUpdateSubscription } from './subscriptions/EventSubChannelRewardUpdateSubscription';
 import { EventSubChannelAutomaticRewardRedemptionAddSubscription } from './subscriptions/EventSubChannelAutomaticRewardRedemptionAddSubscription';
+import { EventSubChannelSharedChatSessionBeginSubscription } from './subscriptions/EventSubChannelSharedChatSessionBeginSubscription';
+import { EventSubChannelSharedChatSessionUpdateSubscription } from './subscriptions/EventSubChannelSharedChatSessionUpdateSubscription';
+import { EventSubChannelSharedChatSessionEndSubscription } from './subscriptions/EventSubChannelSharedChatSessionEndSubscription';
 import { EventSubChannelShieldModeBeginSubscription } from './subscriptions/EventSubChannelShieldModeBeginSubscription';
 import { EventSubChannelShieldModeEndSubscription } from './subscriptions/EventSubChannelShieldModeEndSubscription';
 import { EventSubChannelShoutoutCreateSubscription } from './subscriptions/EventSubChannelShoutoutCreateSubscription';
@@ -1549,6 +1555,48 @@ export abstract class EventSubBase extends EventEmitter {
 			broadcasterId,
 			userId,
 		);
+	}
+
+	/**
+	 * Subscribes to events that indicate the start of a shared chat session in a channel.
+	 *
+	 * @param broadcaster The user for whom to receive notifications when a shared chat session starts in their channel.
+	 * @param handler The function to be called when a new notification is received.
+	 */
+	onChannelSharedChatSessionBegin(
+		broadcaster: UserIdResolvable,
+		handler: (data: EventSubChannelSharedChatSessionBeginEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelSharedChatSessionBegin');
+		return this._genericSubscribe(EventSubChannelSharedChatSessionBeginSubscription, handler, this, broadcasterId);
+	}
+
+	/**
+	 * Subscribes to events that indicate updates to a shared chat session in a channel.
+	 *
+	 * @param broadcaster The user for whom to receive notifications when a shared chat session is updated in their channel.
+	 * @param handler The function to be called when a new notification is received.
+	 */
+	onChannelSharedChatSessionUpdate(
+		broadcaster: UserIdResolvable,
+		handler: (data: EventSubChannelSharedChatSessionUpdateEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelSharedChatSessionUpdate');
+		return this._genericSubscribe(EventSubChannelSharedChatSessionUpdateSubscription, handler, this, broadcasterId);
+	}
+
+	/**
+	 * Subscribes to events that indicate the end of a shared chat session in a channel.
+	 *
+	 * @param broadcaster The user for whom to receive notifications when a shared chat session ends in their channel.
+	 * @param handler The function to be called when a new notification is received.
+	 */
+	onChannelSharedChatSessionEnd(
+		broadcaster: UserIdResolvable,
+		handler: (data: EventSubChannelSharedChatSessionEndEvent) => void,
+	): EventSubSubscription {
+		const broadcasterId = this._extractUserIdWithNumericWarning(broadcaster, 'onChannelSharedChatSessionBegin');
+		return this._genericSubscribe(EventSubChannelSharedChatSessionEndSubscription, handler, this, broadcasterId);
 	}
 
 	/**

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -57,6 +57,9 @@ import type { EventSubChannelUpdateEvent } from './events/EventSubChannelUpdateE
 import { type EventSubChannelVipEvent } from './events/EventSubChannelVipEvent';
 import { type EventSubChannelWarningAcknowledgeEvent } from './events/EventSubChannelWarningAcknowledgeEvent';
 import { type EventSubChannelWarningSendEvent } from './events/EventSubChannelWarningSendEvent';
+import { type EventSubChannelSharedChatSessionBeginEvent } from './events/EventSubChannelSharedChatSessionBeginEvent';
+import { type EventSubChannelSharedChatSessionUpdateEvent } from './events/EventSubChannelSharedChatSessionUpdateEvent';
+import { type EventSubChannelSharedChatSessionEndEvent } from './events/EventSubChannelSharedChatSessionEndEvent';
 import { type EventSubDropEntitlementGrantEvent } from './events/EventSubDropEntitlementGrantEvent';
 import type { EventSubExtensionBitsTransactionCreateEvent } from './events/EventSubExtensionBitsTransactionCreateEvent';
 import type { EventSubStreamOfflineEvent } from './events/EventSubStreamOfflineEvent';
@@ -912,6 +915,39 @@ export interface EventSubListener {
 		broadcaster: UserIdResolvable,
 		user: UserIdResolvable,
 		handler: (data: EventSubChannelChatUserMessageUpdateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that indicate the start of a shared chat session in a channel.
+	 *
+	 * @param broadcaster The user for whom to receive notifications when a shared chat session starts in their channel.
+	 * @param handler The function to be called when a new notification is received.
+	 */
+	onChannelSharedChatSessionBegin: (
+		broadcaster: UserIdResolvable,
+		handler: (data: EventSubChannelSharedChatSessionBeginEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that indicate updates to a shared chat session in a channel.
+	 *
+	 * @param broadcaster The user for whom to receive notifications when a shared chat session is updated in their channel.
+	 * @param handler The function to be called when a new notification is received.
+	 */
+	onChannelSharedChatSessionUpdate: (
+		broadcaster: UserIdResolvable,
+		handler: (data: EventSubChannelSharedChatSessionUpdateEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that indicate the end of a shared chat session in a channel.
+	 *
+	 * @param broadcaster The user for whom to receive notifications when a shared chat session ends in their channel.
+	 * @param handler The function to be called when a new notification is received.
+	 */
+	onChannelSharedChatSessionEnd: (
+		broadcaster: UserIdResolvable,
+		handler: (data: EventSubChannelSharedChatSessionEndEvent) => void,
 	) => EventSubSubscription;
 
 	/**

--- a/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.external.ts
@@ -39,4 +39,9 @@ export interface EventSubChannelChatMessageEventData {
 	color: string;
 	reply: EventSubChatMessageReplyData | null;
 	channel_points_custom_reward_id: string | null;
+	source_broadcaster_user_id: string | null;
+	source_broadcaster_user_login: string | null;
+	source_broadcaster_user_name: string | null;
+	source_message_id: string | null;
+	source_badges: EventSubChatBadge[] | null;
 }

--- a/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.ts
@@ -225,4 +225,84 @@ export class EventSubChannelChatMessageEvent extends DataObject<EventSubChannelC
 	get rewardId(): string | null {
 		return this[rawDataSymbol].channel_points_custom_reward_id ?? null;
 	}
+
+	/**
+	 * The ID of the broadcaster from whose channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceBroadcasterId(): string | null {
+		return this[rawDataSymbol].source_broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster from whose channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceBroadcasterName(): string | null {
+		return this[rawDataSymbol].source_broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster from whose channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceBroadcasterDisplayName(): string | null {
+		return this[rawDataSymbol].source_broadcaster_user_name;
+	}
+
+	/**
+	 * The UUID that identifies the source message from the channel the message was sent from.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceMessageId(): string | null {
+		return this[rawDataSymbol].source_message_id;
+	}
+
+	/**
+	 * The chat badges for the chatter in the channel the message was sent from.
+	 *
+	 * The returned object contains the badge names as keys and the badge versions as the respective values.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceBadges(): Record<string, string> | null {
+		return this[rawDataSymbol].source_badges
+			? Object.fromEntries(this[rawDataSymbol].source_badges.map(badge => [badge.set_id, badge.id]))
+			: null;
+	}
+
+	/**
+	 * Checks whether the chatter has the specified badge.
+	 *
+	 * This only applies if a chatter sends a chat message to another chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 *
+	 * @param name The name of the badge to check.
+	 */
+	hasSourceBadge(name: string): boolean | null {
+		return this[rawDataSymbol].source_badges
+			? this[rawDataSymbol].source_badges.some(badge => badge.set_id === name)
+			: null;
+	}
+
+	/**
+	 * Gets the badge info for a specified badge.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster, or if the badge does not exist.
+	 *
+	 * @param name The name of the badge to get info for.
+	 */
+	getSourceBadgeInfo(name: string): string | null {
+		return this[rawDataSymbol].source_badges?.find(badge => badge.set_id === name)?.info ?? null;
+	}
 }

--- a/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionBeginEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionBeginEvent.external.ts
@@ -1,0 +1,13 @@
+import { type EventSubChannelSharedChatSessionParticipantData } from './common/EventSubChannelSharedChatSessionParticipant.external';
+
+/** @private */
+export interface EventSubChannelSharedChatSessionBeginEventData {
+	session_id: string;
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	host_broadcaster_user_id: string;
+	host_broadcaster_user_login: string;
+	host_broadcaster_user_name: string;
+	participants: EventSubChannelSharedChatSessionParticipantData[];
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionBeginEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionBeginEvent.ts
@@ -1,0 +1,97 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { type EventSubChannelSharedChatSessionBeginEventData } from './EventSubChannelSharedChatSessionBeginEvent.external';
+import { EventSubChannelSharedChatSessionParticipant } from './common/EventSubChannelSharedChatSessionParticipant';
+
+/**
+ * An EventSub event representing the start of a shared chat session in a channel.
+ */
+@rtfm<EventSubChannelSharedChatSessionBeginEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatSessionBeginEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatSessionBeginEvent extends DataObject<EventSubChannelSharedChatSessionBeginEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelSharedChatSessionBeginEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The unique identifier for the shared chat session.
+	 */
+	get sessionId(): string {
+		return this[rawDataSymbol].session_id;
+	}
+
+	/**
+	 * The ID of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the host broadcaster.
+	 */
+	get hostBroadcasterId(): string {
+		return this[rawDataSymbol].host_broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the host broadcaster.
+	 */
+	get hostBroadcasterName(): string {
+		return this[rawDataSymbol].host_broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the host broadcaster.
+	 */
+	get hostBroadcasterDisplayName(): string {
+		return this[rawDataSymbol].host_broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the broadcaster.
+	 */
+	async getHostBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(
+			await this._client.users.getUserById(this[rawDataSymbol].host_broadcaster_user_id),
+		);
+	}
+
+	/**
+	 * The list of all participants currently in the shared chat session.
+	 */
+	get participants(): EventSubChannelSharedChatSessionParticipant[] {
+		return this[rawDataSymbol].participants.map(
+			participant => new EventSubChannelSharedChatSessionParticipant(participant, this._client),
+		);
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionEndEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionEndEvent.external.ts
@@ -1,0 +1,10 @@
+/** @private */
+export interface EventSubChannelSharedChatSessionEndEventData {
+	session_id: string;
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	host_broadcaster_user_id: string;
+	host_broadcaster_user_login: string;
+	host_broadcaster_user_name: string;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionEndEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionEndEvent.ts
@@ -1,0 +1,87 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type ApiClient, type HelixUser } from '@twurple/api';
+import { type EventSubChannelSharedChatSessionEndEventData } from './EventSubChannelSharedChatSessionEndEvent.external';
+
+/**
+ * An EventSub event representing the end of a shared chat session in a channel.
+ */
+@rtfm<EventSubChannelSharedChatSessionEndEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatSessionEndEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatSessionEndEvent extends DataObject<EventSubChannelSharedChatSessionEndEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelSharedChatSessionEndEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The unique identifier for the shared chat session.
+	 */
+	get sessionId(): string {
+		return this[rawDataSymbol].session_id;
+	}
+
+	/**
+	 * The ID of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the host broadcaster.
+	 */
+	get hostBroadcasterId(): string {
+		return this[rawDataSymbol].host_broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the host broadcaster.
+	 */
+	get hostBroadcasterName(): string {
+		return this[rawDataSymbol].host_broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the host broadcaster.
+	 */
+	get hostBroadcasterDisplayName(): string {
+		return this[rawDataSymbol].host_broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the broadcaster.
+	 */
+	async getHostBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(
+			await this._client.users.getUserById(this[rawDataSymbol].host_broadcaster_user_id),
+		);
+	}
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionUpdateEvent.external.ts
@@ -1,0 +1,13 @@
+import { type EventSubChannelSharedChatSessionParticipantData } from './common/EventSubChannelSharedChatSessionParticipant.external';
+
+/** @private */
+export interface EventSubChannelSharedChatSessionUpdateEventData {
+	session_id: string;
+	broadcaster_user_id: string;
+	broadcaster_user_login: string;
+	broadcaster_user_name: string;
+	host_broadcaster_user_id: string;
+	host_broadcaster_user_login: string;
+	host_broadcaster_user_name: string;
+	participants: EventSubChannelSharedChatSessionParticipantData[];
+}

--- a/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelSharedChatSessionUpdateEvent.ts
@@ -1,0 +1,97 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { EventSubChannelSharedChatSessionParticipant } from './common/EventSubChannelSharedChatSessionParticipant';
+import { type EventSubChannelSharedChatSessionUpdateEventData } from './EventSubChannelSharedChatSessionUpdateEvent.external';
+
+/**
+ * An EventSub event representing an update to a shared chat session in a channel.
+ */
+@rtfm<EventSubChannelSharedChatSessionUpdateEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatSessionUpdateEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatSessionUpdateEvent extends DataObject<EventSubChannelSharedChatSessionUpdateEventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelSharedChatSessionUpdateEventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The unique identifier for the shared chat session.
+	 */
+	get sessionId(): string {
+		return this[rawDataSymbol].session_id;
+	}
+
+	/**
+	 * The ID of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in the subscription condition which is now active in the shared chat session.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the host broadcaster.
+	 */
+	get hostBroadcasterId(): string {
+		return this[rawDataSymbol].host_broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the host broadcaster.
+	 */
+	get hostBroadcasterName(): string {
+		return this[rawDataSymbol].host_broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the host broadcaster.
+	 */
+	get hostBroadcasterDisplayName(): string {
+		return this[rawDataSymbol].host_broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the broadcaster.
+	 */
+	async getHostBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(
+			await this._client.users.getUserById(this[rawDataSymbol].host_broadcaster_user_id),
+		);
+	}
+
+	/**
+	 * The list of participants in the session.
+	 */
+	get participants(): EventSubChannelSharedChatSessionParticipant[] {
+		return this[rawDataSymbol].participants.map(
+			participant => new EventSubChannelSharedChatSessionParticipant(participant, this._client),
+		);
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatBaseNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatBaseNotificationEvent.ts
@@ -148,4 +148,84 @@ export abstract class EventSubChannelChatBaseNotificationEvent extends DataObjec
 	get messageParts(): EventSubChatMessagePart[] {
 		return this[rawDataSymbol].message.fragments;
 	}
+
+	/**
+	 * The ID of the broadcaster from whose channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message notification happens in the same channel as the broadcaster.
+	 */
+	get sourceBroadcasterId(): string | null {
+		return this[rawDataSymbol].source_broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster from whose channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message notification happens in the same channel as the broadcaster.
+	 */
+	get sourceBroadcasterName(): string | null {
+		return this[rawDataSymbol].source_broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster from whose channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message notification happens in the same channel as the broadcaster.
+	 */
+	get sourceBroadcasterDisplayName(): string | null {
+		return this[rawDataSymbol].source_broadcaster_user_name;
+	}
+
+	/**
+	 * The UUID that identifies the source message from the channel the message was sent.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceMessageId(): string | null {
+		return this[rawDataSymbol].source_message_id;
+	}
+
+	/**
+	 * The chat badges for the chatter in the channel the message was sent from.
+	 *
+	 * The returned object contains the badge names as keys and the badge versions as the respective values.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 */
+	get sourceBadges(): Record<string, string> | null {
+		return this[rawDataSymbol].source_badges
+			? Object.fromEntries(this[rawDataSymbol].source_badges.map(badge => [badge.set_id, badge.id]))
+			: null;
+	}
+
+	/**
+	 * Checks whether the chatter has the specified badge.
+	 *
+	 * This only applies if a chatter sends a chat message to another chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster.
+	 *
+	 * @param name The name of the badge to check.
+	 */
+	hasSourceBadge(name: string): boolean | null {
+		return this[rawDataSymbol].source_badges
+			? this[rawDataSymbol].source_badges.some(badge => badge.set_id === name)
+			: null;
+	}
+
+	/**
+	 * Gets the badge info for a specified badge.
+	 *
+	 * This only applies if a chatter sends a chat message in another channel's chat during a shared chat session.
+	 * Is `null` when the message happens in the same channel as the broadcaster, or if the badge does not exist.
+	 *
+	 * @param name The name of the badge to get info for.
+	 */
+	getSourceBadgeInfo(name: string): string | null {
+		return this[rawDataSymbol].source_badges?.find(badge => badge.set_id === name)?.info ?? null;
+	}
 }

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.external.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.external.ts
@@ -12,8 +12,17 @@ export type EventSubChannelChatNotificationType =
 	| 'unraid'
 	| 'pay_it_forward'
 	| 'announcement'
+	| 'bits_badge_tier'
 	| 'charity_donation'
-	| 'bits_badge_tier';
+	| 'shared_chat_sub'
+	| 'shared_chat_resub'
+	| 'shared_chat_sub_gift'
+	| 'shared_chat_community_sub_gift'
+	| 'shared_chat_gift_paid_upgrade'
+	| 'shared_chat_prime_paid_upgrade'
+	| 'shared_chat_raid'
+	| 'shared_chat_pay_it_forward'
+	| 'shared_chat_announcement';
 
 /**
  * The tier of a subscription. 1000 means tier 1, and so on.
@@ -43,6 +52,11 @@ export interface EventSubChannelChatBaseNotificationEventData {
 	system_message: string;
 	message_id: string;
 	message: EventSubChatMessageData;
+	source_broadcaster_user_id: string | null;
+	source_broadcaster_user_login: string | null;
+	source_broadcaster_user_name: string | null;
+	source_message_id: string | null;
+	source_badges: EventSubChatBadge[] | null;
 }
 
 /** @private */
@@ -199,6 +213,69 @@ export interface EventSubChannelChatBitsBadgeTierNotificationEventData
 }
 
 /** @private */
+export interface EventSubChannelChatSharedChatSubNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_sub';
+	shared_chat_sub: EventSubChannelChatSubNotificationPayload;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatResubNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_resub';
+	shared_chat_resub: EventSubChannelChatResubNotificationPayload;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatSubGiftNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_sub_gift';
+	shared_chat_sub_gift: EventSubChannelChatSubGiftNotificationPayload;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatCommunitySubGiftNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_community_sub_gift';
+	shared_chat_community_sub_gift: EventSubChannelChatCommunitySubGiftNotificationPayload;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_gift_paid_upgrade';
+	shared_chat_gift_paid_upgrade: EventSubChannelChatNotificationOriginalGifterData;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_prime_paid_upgrade';
+	shared_chat_prime_paid_upgrade: EventSubChannelChatPrimePaidUpgradeNotificationPayload;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatRaidNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_raid';
+	shared_chat_raid: EventSubChannelChatRaidNotificationPayload;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatPayItForwardNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_pay_it_forward';
+	shared_chat_pay_it_forward: EventSubChannelChatNotificationOriginalGifterData;
+}
+
+/** @private */
+export interface EventSubChannelChatSharedChatAnnouncementNotificationEventData
+	extends EventSubChannelChatBaseNotificationEventData {
+	notice_type: 'shared_chat_announcement';
+	shared_chat_announcement: EventSubChannelChatAnnouncementNotificationPayload;
+}
+
+/** @private */
 export type EventSubChannelChatNotificationEventData =
 	| EventSubChannelChatSubNotificationEventData
 	| EventSubChannelChatResubNotificationEventData
@@ -211,4 +288,13 @@ export type EventSubChannelChatNotificationEventData =
 	| EventSubChannelChatPayItForwardNotificationEventData
 	| EventSubChannelChatAnnouncementNotificationEventData
 	| EventSubChannelChatCharityDonationNotificationEventData
-	| EventSubChannelChatBitsBadgeTierNotificationEventData;
+	| EventSubChannelChatBitsBadgeTierNotificationEventData
+	| EventSubChannelChatSharedChatSubNotificationEventData
+	| EventSubChannelChatSharedChatResubNotificationEventData
+	| EventSubChannelChatSharedChatSubGiftNotificationEventData
+	| EventSubChannelChatSharedChatCommunitySubGiftNotificationEventData
+	| EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEventData
+	| EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEventData
+	| EventSubChannelChatSharedChatRaidNotificationEventData
+	| EventSubChannelChatSharedChatPayItForwardNotificationEventData
+	| EventSubChannelChatSharedChatAnnouncementNotificationEventData;

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.external.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.external.ts
@@ -1,7 +1,6 @@
 import { type EventSubChannelCharityAmountData } from '../common/EventSubChannelCharityAmount.external';
 import { type EventSubChatBadge, type EventSubChatMessageData } from '../common/EventSubChatMessage.external';
 
-/** @private */
 export type EventSubChannelChatNotificationType =
 	| 'sub'
 	| 'resub'

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatNotificationEvent.ts
@@ -10,6 +10,15 @@ import { type EventSubChannelChatResubNotificationEvent } from './EventSubChanne
 import { type EventSubChannelChatSubGiftNotificationEvent } from './EventSubChannelChatSubGiftNotificationEvent';
 import { type EventSubChannelChatSubNotificationEvent } from './EventSubChannelChatSubNotificationEvent';
 import { type EventSubChannelChatUnraidNotificationEvent } from './EventSubChannelChatUnraidNotificationEvent';
+import { type EventSubChannelChatSharedChatPayItForwardNotificationEvent } from './EventSubChannelChatSharedChatPayItForwardNotificationEvent';
+import { type EventSubChannelChatSharedChatSubNotificationEvent } from './EventSubChannelChatSharedChatSubNotificationEvent';
+import { type EventSubChannelChatSharedChatResubNotificationEvent } from './EventSubChannelChatSharedChatResubNotificationEvent';
+import { type EventSubChannelChatSharedChatSubGiftNotificationEvent } from './EventSubChannelChatSharedChatSubGiftNotificationEvent';
+import { type EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent } from './EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent';
+import { type EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent } from './EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent';
+import { type EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent } from './EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent';
+import { type EventSubChannelChatSharedChatRaidNotificationEvent } from './EventSubChannelChatSharedChatRaidNotificationEvent';
+import { type EventSubChannelChatSharedChatAnnouncementNotificationEvent } from './EventSubChannelChatSharedChatAnnouncementNotificationEvent';
 
 export type EventSubChannelChatNotificationEvent =
 	| EventSubChannelChatSubNotificationEvent
@@ -23,4 +32,13 @@ export type EventSubChannelChatNotificationEvent =
 	| EventSubChannelChatPayItForwardNotificationEvent
 	| EventSubChannelChatAnnouncementNotificationEvent
 	| EventSubChannelChatCharityDonationNotificationEvent
-	| EventSubChannelChatBitsBadgeTierNotificationEvent;
+	| EventSubChannelChatBitsBadgeTierNotificationEvent
+	| EventSubChannelChatSharedChatSubNotificationEvent
+	| EventSubChannelChatSharedChatResubNotificationEvent
+	| EventSubChannelChatSharedChatSubGiftNotificationEvent
+	| EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent
+	| EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent
+	| EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent
+	| EventSubChannelChatSharedChatPayItForwardNotificationEvent
+	| EventSubChannelChatSharedChatRaidNotificationEvent
+	| EventSubChannelChatSharedChatAnnouncementNotificationEvent;

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatAnnouncementNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatAnnouncementNotificationEvent.ts
@@ -1,0 +1,28 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import {
+	type EventSubChannelChatAnnouncementColor,
+	type EventSubChannelChatSharedChatAnnouncementNotificationEventData,
+} from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a notification for an announcement in another channel's chat during a shared chat
+ * session.
+ */
+@rtfm<EventSubChannelChatSharedChatAnnouncementNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatAnnouncementNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatAnnouncementNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatAnnouncementNotificationEventData;
+
+	readonly type = 'shared_chat_announcement';
+
+	/**
+	 * The color of the announcement.
+	 */
+	get color(): EventSubChannelChatAnnouncementColor {
+		return this[rawDataSymbol].shared_chat_announcement.color;
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent.ts
@@ -1,0 +1,49 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import {
+	type EventSubChannelChatNotificationSubTier,
+	type EventSubChannelChatSharedChatCommunitySubGiftNotificationEventData,
+} from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a community sub gift notification in another channel's chat during a shared chat
+ * session.
+ */
+@rtfm<EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatCommunitySubGiftNotificationEventData;
+
+	readonly type = 'shared_chat_community_sub_gift';
+
+	/**
+	 * The ID of the community sub gift.
+	 */
+	get id(): string {
+		return this[rawDataSymbol].shared_chat_community_sub_gift.id;
+	}
+
+	/**
+	 * The tier of the subscriptions.
+	 */
+	get tier(): EventSubChannelChatNotificationSubTier {
+		return this[rawDataSymbol].shared_chat_community_sub_gift.sub_tier;
+	}
+
+	/**
+	 * The amount of gifts that are part of this community sub gift.
+	 */
+	get amount(): number {
+		return this[rawDataSymbol].shared_chat_community_sub_gift.total;
+	}
+
+	/**
+	 * The amount of gifts that the gifter has sent in total, or `null` the gift is anonymous.
+	 */
+	get cumulativeAmount(): number | null {
+		return this[rawDataSymbol].shared_chat_community_sub_gift.cumulative_total;
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent.ts
@@ -1,0 +1,58 @@
+import { mapNullable } from '@d-fischer/shared-utils';
+import { type HelixUser } from '@twurple/api';
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import { type EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEventData } from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a notification of a user upgrading their gifted sub to a paid one in another channel's
+ * chat during a shared chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEventData;
+
+	readonly type = 'shared_chat_gift_paid_upgrade';
+
+	/**
+	 * Whether the original gifter is anonymous.
+	 */
+	get isGifterAnonymous(): boolean {
+		return this[rawDataSymbol].shared_chat_gift_paid_upgrade.gifter_is_anonymous;
+	}
+
+	/**
+	 * The ID of the original gifter, or `null` if they're anonymous.
+	 */
+	get gifterId(): string | null {
+		return this[rawDataSymbol].shared_chat_gift_paid_upgrade.gifter_user_id;
+	}
+
+	/**
+	 * The username of the original gifter, or `null` if they're anonymous.
+	 */
+	get gifterName(): string | null {
+		return this[rawDataSymbol].shared_chat_gift_paid_upgrade.gifter_user_login;
+	}
+
+	/**
+	 * The display name of the original gifter, or `null` if they're anonymous.
+	 */
+	get gifterDisplayName(): string | null {
+		return this[rawDataSymbol].shared_chat_gift_paid_upgrade.gifter_user_name;
+	}
+
+	/**
+	 * Gets more information about the original gifter, or `null` if they're anonymous.
+	 */
+	async getGifter(): Promise<HelixUser | null> {
+		return await mapNullable(
+			this[rawDataSymbol].shared_chat_gift_paid_upgrade.gifter_user_id,
+			async id => await this._client.users.getUserById(id),
+		);
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatPayItForwardNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatPayItForwardNotificationEvent.ts
@@ -1,0 +1,58 @@
+import { mapNullable } from '@d-fischer/shared-utils';
+import { type HelixUser } from '@twurple/api';
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import { type EventSubChannelChatSharedChatPayItForwardNotificationEventData } from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a notification of a user "paying it forward" in another channel's chat during a shared
+ * chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatPayItForwardNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatPayItForwardNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatPayItForwardNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatPayItForwardNotificationEventData;
+
+	readonly type = 'shared_chat_pay_it_forward';
+
+	/**
+	 * Whether the original gifter is anonymous.
+	 */
+	get isGifterAnonymous(): boolean {
+		return this[rawDataSymbol].shared_chat_pay_it_forward.gifter_is_anonymous;
+	}
+
+	/**
+	 * The ID of the original gifter, or `null` if they're anonymous.
+	 */
+	get gifterId(): string | null {
+		return this[rawDataSymbol].shared_chat_pay_it_forward.gifter_user_id;
+	}
+
+	/**
+	 * The username of the original gifter, or `null` if they're anonymous.
+	 */
+	get gifterName(): string | null {
+		return this[rawDataSymbol].shared_chat_pay_it_forward.gifter_user_login;
+	}
+
+	/**
+	 * The display name of the original gifter, or `null` if they're anonymous.
+	 */
+	get gifterDisplayName(): string | null {
+		return this[rawDataSymbol].shared_chat_pay_it_forward.gifter_user_name;
+	}
+
+	/**
+	 * Gets more information about the original gifter, or `null` if they're anonymous.
+	 */
+	async getGifter(): Promise<HelixUser | null> {
+		return await mapNullable(
+			this[rawDataSymbol].shared_chat_pay_it_forward.gifter_user_id,
+			async id => await this._client.users.getUserById(id),
+		);
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent.ts
@@ -1,0 +1,25 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import {
+	type EventSubChannelChatNotificationSubTier,
+	type EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEventData,
+} from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a notification of a user upgrading their gifted sub to a paid one in another channel's
+ * chat during a shared chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEventData;
+
+	readonly type = 'shared_chat_prime_paid_upgrade';
+
+	get tier(): EventSubChannelChatNotificationSubTier {
+		return this[rawDataSymbol].shared_chat_prime_paid_upgrade.sub_tier;
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatRaidNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatRaidNotificationEvent.ts
@@ -1,0 +1,62 @@
+import { type HelixUser } from '@twurple/api';
+import { checkRelationAssertion, rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import { type EventSubChannelChatSharedChatRaidNotificationEventData } from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing an incoming raid notification in another channel's chat during a shared chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatRaidNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatRaidNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatRaidNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatRaidNotificationEventData;
+
+	readonly type = 'shared_chat_raid';
+
+	/**
+	 * The ID of the user that raided the channel.
+	 */
+	get raiderId(): string {
+		return this[rawDataSymbol].shared_chat_raid.user_id;
+	}
+
+	/**
+	 * The username of the user that raided the channel.
+	 */
+	get raiderName(): string {
+		return this[rawDataSymbol].shared_chat_raid.user_login;
+	}
+
+	/**
+	 * The display name of the user that raided the channel.
+	 */
+	get raiderDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_raid.user_name;
+	}
+
+	/**
+	 * Gets more information about the user that raided the channel.
+	 */
+	async getRaider(): Promise<HelixUser> {
+		return checkRelationAssertion(
+			await this._client.users.getUserById(this[rawDataSymbol].shared_chat_raid.user_id),
+		);
+	}
+
+	/**
+	 * The amount of viewers the channel was raided with.
+	 */
+	get viewerCount(): number {
+		return this[rawDataSymbol].shared_chat_raid.viewer_count;
+	}
+
+	/**
+	 * The URL to the profile image of the user that raided the channel.
+	 */
+	get raiderProfileImageUrl(): string {
+		return this[rawDataSymbol].shared_chat_raid.profile_image_url;
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatResubNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatResubNotificationEvent.ts
@@ -1,0 +1,102 @@
+import { mapNullable } from '@d-fischer/shared-utils';
+import { type HelixUser } from '@twurple/api';
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import {
+	type EventSubChannelChatNotificationSubTier,
+	type EventSubChannelChatSharedChatResubNotificationEventData,
+} from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a resub notification in another channel's chat during a shared chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatResubNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatResubNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatResubNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatResubNotificationEventData;
+
+	readonly type = 'shared_chat_resub';
+
+	/**
+	 * The tier of the subscription.
+	 */
+	get tier(): EventSubChannelChatNotificationSubTier {
+		return this[rawDataSymbol].shared_chat_resub.sub_tier;
+	}
+
+	/**
+	 * Whether the subscription was "paid" for using Prime Gaming.
+	 */
+	get isPrime(): boolean {
+		return this[rawDataSymbol].shared_chat_resub.is_prime;
+	}
+
+	/**
+	 * The number of months the subscription is for.
+	 */
+	get durationMonths(): number {
+		return this[rawDataSymbol].shared_chat_resub.duration_months || 1;
+	}
+
+	/**
+	 * The total number of months the user has subscribed for.
+	 */
+	get cumulativeMonths(): number {
+		return this[rawDataSymbol].shared_chat_resub.cumulative_months;
+	}
+
+	/**
+	 * The streak amount of months the user has been subscribed for, or `null` if not shared.
+	 */
+	get streakMonths(): number | null {
+		return this[rawDataSymbol].shared_chat_resub.streak_months ?? null;
+	}
+
+	/**
+	 * Whether the resub was gifted by another user.
+	 */
+	get isGift(): boolean {
+		return this[rawDataSymbol].shared_chat_resub.is_gift;
+	}
+
+	/**
+	 * Whether the gifter is anonymous, or `null` if this is not a gift.
+	 */
+	get isGifterAnonymous(): boolean | null {
+		return this[rawDataSymbol].shared_chat_resub.gifter_is_anonymous ?? null;
+	}
+
+	/**
+	 * The ID of the gifter, or `null` if they're anonymous or this is not a gift.
+	 */
+	get gifterId(): string | null {
+		return this[rawDataSymbol].shared_chat_resub.gifter_user_id;
+	}
+
+	/**
+	 * The username of the gifter, or `null` if they're anonymous or this is not a gift.
+	 */
+	get gifterName(): string | null {
+		return this[rawDataSymbol].shared_chat_resub.gifter_user_login;
+	}
+
+	/**
+	 * The display name of the gifter, or `null` if they're anonymous or this is not a gift.
+	 */
+	get gifterDisplayName(): string | null {
+		return this[rawDataSymbol].shared_chat_resub.gifter_user_name;
+	}
+
+	/**
+	 * Gets more information about the gifter, or `null` if they're anonymous or this is not a gift.
+	 */
+	async getGifter(): Promise<HelixUser | null> {
+		return await mapNullable(
+			this[rawDataSymbol].shared_chat_resub.gifter_user_id,
+			async id => await this._client.users.getUserById(id),
+		);
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatSubGiftNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatSubGiftNotificationEvent.ts
@@ -1,0 +1,79 @@
+import { type HelixUser } from '@twurple/api';
+import { checkRelationAssertion, rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import {
+	type EventSubChannelChatNotificationSubTier,
+	type EventSubChannelChatSharedChatSubGiftNotificationEventData,
+} from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a sub gift notification in another channel's chat during a shared chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatSubGiftNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatSubGiftNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatSubGiftNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatSubGiftNotificationEventData;
+
+	readonly type = 'shared_chat_sub_gift';
+
+	/**
+	 * The tier of the subscription.
+	 */
+	get tier(): EventSubChannelChatNotificationSubTier {
+		return this[rawDataSymbol].shared_chat_sub_gift.sub_tier;
+	}
+
+	/**
+	 * The number of months the subscription is for.
+	 */
+	get durationMonths(): number {
+		return this[rawDataSymbol].shared_chat_sub_gift.duration_months || 1;
+	}
+
+	/**
+	 * The amount of gifts that the gifter has sent in total, or `null` the gift is anonymous.
+	 */
+	get cumulativeAmount(): number | null {
+		return this[rawDataSymbol].shared_chat_sub_gift.cumulative_total;
+	}
+
+	/**
+	 * The ID of the recipient.
+	 */
+	get recipientId(): string {
+		return this[rawDataSymbol].shared_chat_sub_gift.recipient_user_id;
+	}
+
+	/**
+	 * The username of the recipient.
+	 */
+	get recipientName(): string {
+		return this[rawDataSymbol].shared_chat_sub_gift.recipient_user_login;
+	}
+
+	/**
+	 * The display name of the recipient.
+	 */
+	get recipientDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_sub_gift.recipient_user_name;
+	}
+
+	/**
+	 * Gets more information about the recipient.
+	 */
+	async getRecipient(): Promise<HelixUser> {
+		return checkRelationAssertion(
+			await this._client.users.getUserById(this[rawDataSymbol].shared_chat_sub_gift.recipient_user_id),
+		);
+	}
+
+	/**
+	 * The id of the community gift the sub gift belongs to, or `null` if it doesn't belong to any community gift.
+	 */
+	get communityGiftId(): string | null {
+		return this[rawDataSymbol].shared_chat_sub_gift.community_gift_id;
+	}
+}

--- a/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatSubNotificationEvent.ts
+++ b/packages/eventsub-base/src/events/chatNotifications/EventSubChannelChatSharedChatSubNotificationEvent.ts
@@ -1,0 +1,41 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelChatBaseNotificationEvent } from './EventSubChannelChatBaseNotificationEvent';
+import {
+	type EventSubChannelChatNotificationSubTier,
+	type EventSubChannelChatSharedChatSubNotificationEventData,
+} from './EventSubChannelChatNotificationEvent.external';
+
+/**
+ * An EventSub event representing a sub notification in another channel's chat during a shared chat session.
+ */
+@rtfm<EventSubChannelChatSharedChatSubNotificationEvent>(
+	'eventsub-base',
+	'EventSubChannelChatSharedChatSubNotificationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelChatSharedChatSubNotificationEvent extends EventSubChannelChatBaseNotificationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelChatSharedChatSubNotificationEventData;
+
+	readonly type = 'shared_chat_sub';
+
+	/**
+	 * The tier of the subscription.
+	 */
+	get tier(): EventSubChannelChatNotificationSubTier {
+		return this[rawDataSymbol].shared_chat_sub.sub_tier;
+	}
+
+	/**
+	 * Whether the subscription was "paid" for using Prime Gaming.
+	 */
+	get isPrime(): boolean {
+		return this[rawDataSymbol].shared_chat_sub.is_prime;
+	}
+
+	/**
+	 * The number of months the subscription is for.
+	 */
+	get durationMonths(): number {
+		return this[rawDataSymbol].shared_chat_sub.duration_months;
+	}
+}

--- a/packages/eventsub-base/src/events/common/EventSubChannelSharedChatSessionParticipant.external.ts
+++ b/packages/eventsub-base/src/events/common/EventSubChannelSharedChatSessionParticipant.external.ts
@@ -1,0 +1,6 @@
+/** @private */
+export interface EventSubChannelSharedChatSessionParticipantData {
+	broadcaster_user_id: string;
+	broadcaster_user_name: string;
+	broadcaster_user_login: string;
+}

--- a/packages/eventsub-base/src/events/common/EventSubChannelSharedChatSessionParticipant.ts
+++ b/packages/eventsub-base/src/events/common/EventSubChannelSharedChatSessionParticipant.ts
@@ -1,0 +1,50 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import { type ApiClient, type HelixUser } from '@twurple/api';
+import { type EventSubChannelSharedChatSessionParticipantData } from './EventSubChannelSharedChatSessionParticipant.external';
+
+/**
+ * Represents a broadcaster participating in a shared chat session.
+ */
+@rtfm<EventSubChannelSharedChatSessionParticipant>(
+	'eventsub-base',
+	'EventSubChannelSharedChatSessionParticipant',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatSessionParticipant extends DataObject<EventSubChannelSharedChatSessionParticipantData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelSharedChatSessionParticipantData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the participant broadcaster.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the participant broadcaster.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the participant broadcaster.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets information about the participant broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+}

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelModerationEvent.external.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelModerationEvent.external.ts
@@ -30,7 +30,12 @@ export type EventSubChannelModerationAction =
 	| 'remove_permitted_term'
 	| 'approve_unban_request'
 	| 'deny_unban_request'
-	| 'warn';
+	| 'warn'
+	| 'shared_chat_ban'
+	| 'shared_chat_unban'
+	| 'shared_chat_timeout'
+	| 'shared_chat_untimeout'
+	| 'shared_chat_delete';
 
 /**
  * The type of AutoMod terms action.
@@ -207,8 +212,38 @@ export interface EventSubChannelWarnModerationEventPayload extends EventSubChann
 
 /** @private */
 export interface EventSubChannelWarnModerationEventData extends EventSubChannelBaseModerationEventData {
-	action: Extract<EventSubChannelModerationAction, 'delete'>;
+	action: Extract<EventSubChannelModerationAction, 'warn'>;
 	warn: EventSubChannelWarnModerationEventPayload;
+}
+
+/** @private */
+export interface EventSubChannelSharedChatBanModerationEventData extends EventSubChannelBaseModerationEventData {
+	action: Extract<EventSubChannelModerationAction, 'shared_chat_ban'>;
+	shared_chat_ban: EventSubChannelBanModerationEventPayload;
+}
+
+/** @private */
+export interface EventSubChannelSharedChatUnbanModerationEventData extends EventSubChannelBaseModerationEventData {
+	action: Extract<EventSubChannelModerationAction, 'shared_chat_unban'>;
+	shared_chat_unban: EventSubChannelModerationEventUserPayload;
+}
+
+/** @private */
+export interface EventSubChannelSharedChatTimeoutModerationEventData extends EventSubChannelBaseModerationEventData {
+	action: Extract<EventSubChannelModerationAction, 'shared_chat_timeout'>;
+	shared_chat_timeout: EventSubChannelTimeoutModerationEventPayload;
+}
+
+/** @private */
+export interface EventSubChannelSharedChatUntimeoutModerationEventData extends EventSubChannelBaseModerationEventData {
+	action: Extract<EventSubChannelModerationAction, 'shared_chat_untimeout'>;
+	shared_chat_untimeout: EventSubChannelModerationEventUserPayload;
+}
+
+/** @private */
+export interface EventSubChannelSharedChatDeleteModerationEventData extends EventSubChannelBaseModerationEventData {
+	action: Extract<EventSubChannelModerationAction, 'shared_chat_delete'>;
+	shared_chat_delete: EventSubChannelDeleteModerationEventPayload;
 }
 
 /** @private */
@@ -229,4 +264,9 @@ export type EventSubChannelModerationActionEventData =
 	| EventSubChannelDeleteModerationEventData
 	| EventSubChannelAutoModTermsModerationEventData
 	| EventSubChannelUnbanRequestModerationEventData
-	| EventSubChannelWarnModerationEventData;
+	| EventSubChannelWarnModerationEventData
+	| EventSubChannelSharedChatBanModerationEventData
+	| EventSubChannelSharedChatUnbanModerationEventData
+	| EventSubChannelSharedChatTimeoutModerationEventData
+	| EventSubChannelSharedChatUntimeoutModerationEventData
+	| EventSubChannelSharedChatDeleteModerationEventData;

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelModerationEvent.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelModerationEvent.ts
@@ -23,6 +23,11 @@ import { type EventSubChannelUntimeoutModerationEvent } from './EventSubChannelU
 import { type EventSubChannelUnvipModerationEvent } from './EventSubChannelUnvipModerationEvent';
 import { type EventSubChannelVipModerationEvent } from './EventSubChannelVipModerationEvent';
 import { type EventSubChannelWarnModerationEvent } from './EventSubChannelWarnModerationEvent';
+import { type EventSubChannelSharedChatBanModerationEvent } from './EventSubChannelSharedChatBanModerationEvent';
+import { type EventSubChannelSharedChatTimeoutModerationEvent } from './EventSubChannelSharedChatTimeoutModerationEvent';
+import { type EventSubChannelSharedChatUnbanModerationEvent } from './EventSubChannelSharedChatUnbanModerationEvent';
+import { type EventSubChannelSharedChatUntimeoutModerationEvent } from './EventSubChannelSharedChatUntimeoutModerationEvent';
+import { type EventSubChannelSharedChatDeleteModerationEvent } from './EventSubChannelSharedChatDeleteModerationEvent';
 
 export type EventSubChannelModerationEvent =
 	| EventSubChannelAutoModTermsModerationEvent
@@ -49,4 +54,9 @@ export type EventSubChannelModerationEvent =
 	| EventSubChannelUntimeoutModerationEvent
 	| EventSubChannelUnvipModerationEvent
 	| EventSubChannelVipModerationEvent
-	| EventSubChannelWarnModerationEvent;
+	| EventSubChannelWarnModerationEvent
+	| EventSubChannelSharedChatBanModerationEvent
+	| EventSubChannelSharedChatUnbanModerationEvent
+	| EventSubChannelSharedChatTimeoutModerationEvent
+	| EventSubChannelSharedChatUntimeoutModerationEvent
+	| EventSubChannelSharedChatDeleteModerationEvent;

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatBanModerationEvent.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatBanModerationEvent.ts
@@ -1,0 +1,53 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelBaseModerationEvent } from './EventSubChannelBaseModerationEvent';
+import { type EventSubChannelSharedChatBanModerationEventData } from './EventSubChannelModerationEvent.external';
+import type { HelixUser } from '@twurple/api';
+
+/**
+ * An EventSub event representing a moderator banning a user in another channel during a shared chat session.
+ */
+@rtfm<EventSubChannelSharedChatBanModerationEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatBanModerationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatBanModerationEvent extends EventSubChannelBaseModerationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelSharedChatBanModerationEventData;
+
+	override readonly moderationAction = 'shared_chat_ban';
+
+	/**
+	 * The ID of the user being banned.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].shared_chat_ban.user_id;
+	}
+
+	/**
+	 * The name of the user being banned.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].shared_chat_ban.user_login;
+	}
+
+	/**
+	 * The display name of the user being banned.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_ban.user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser | null> {
+		return await this._client.users.getUserById(this[rawDataSymbol].shared_chat_ban.user_id);
+	}
+
+	/**
+	 * The reason given for the ban.
+	 */
+	get reason(): string {
+		return this[rawDataSymbol].shared_chat_ban.reason;
+	}
+}

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatDeleteModerationEvent.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatDeleteModerationEvent.ts
@@ -1,0 +1,60 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelBaseModerationEvent } from './EventSubChannelBaseModerationEvent';
+import { type EventSubChannelSharedChatDeleteModerationEventData } from './EventSubChannelModerationEvent.external';
+import { type HelixUser } from '@twurple/api';
+
+/**
+ * An EventSub event representing a moderator deleting a message in another channel during a shared chat session.
+ */
+@rtfm<EventSubChannelSharedChatDeleteModerationEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatDeleteModerationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatDeleteModerationEvent extends EventSubChannelBaseModerationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelSharedChatDeleteModerationEventData;
+
+	override readonly moderationAction = 'shared_chat_delete';
+
+	/**
+	 * The ID of the user whose message is being deleted.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].shared_chat_delete.user_id;
+	}
+
+	/**
+	 * The name of the user whose message is being deleted.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].shared_chat_delete.user_login;
+	}
+
+	/**
+	 * The display name of the user whose message is being deleted.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_delete.user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser | null> {
+		return await this._client.users.getUserById(this[rawDataSymbol].shared_chat_delete.user_id);
+	}
+
+	/**
+	 * The ID of the message being deleted.
+	 */
+	get messageId(): string {
+		return this[rawDataSymbol].shared_chat_delete.message_id;
+	}
+
+	/**
+	 * The message text of the message being deleted.
+	 */
+	get messageText(): string {
+		return this[rawDataSymbol].shared_chat_delete.message_body;
+	}
+}

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatTimeoutModerationEvent.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatTimeoutModerationEvent.ts
@@ -1,0 +1,60 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelBaseModerationEvent } from './EventSubChannelBaseModerationEvent';
+import { type EventSubChannelSharedChatTimeoutModerationEventData } from './EventSubChannelModerationEvent.external';
+import type { HelixUser } from '@twurple/api';
+
+/**
+ * An EventSub event representing a moderator timing out a user in another channel during a shared chat session.
+ */
+@rtfm<EventSubChannelSharedChatTimeoutModerationEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatTimeoutModerationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatTimeoutModerationEvent extends EventSubChannelBaseModerationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelSharedChatTimeoutModerationEventData;
+
+	override readonly moderationAction = 'shared_chat_timeout';
+
+	/**
+	 * The ID of the user being timed out.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].shared_chat_timeout.user_id;
+	}
+
+	/**
+	 * The name of the user being timed out.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].shared_chat_timeout.user_login;
+	}
+
+	/**
+	 * The display name of the user being timed out.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_timeout.user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser | null> {
+		return await this._client.users.getUserById(this[rawDataSymbol].shared_chat_timeout.user_id);
+	}
+
+	/**
+	 * The reason given for the timeout.
+	 */
+	get reason(): string {
+		return this[rawDataSymbol].shared_chat_timeout.reason;
+	}
+
+	/**
+	 * The time at which the timeout ends.
+	 */
+	get expiryDate(): Date {
+		return new Date(this[rawDataSymbol].shared_chat_timeout.expires_at);
+	}
+}

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatUnbanModerationEvent.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatUnbanModerationEvent.ts
@@ -1,0 +1,46 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelBaseModerationEvent } from './EventSubChannelBaseModerationEvent';
+import { type EventSubChannelSharedChatUnbanModerationEventData } from './EventSubChannelModerationEvent.external';
+import type { HelixUser } from '@twurple/api';
+
+/**
+ * An EventSub event representing a moderator unbanning a user in another channel during a shared chat session.
+ */
+@rtfm<EventSubChannelSharedChatUnbanModerationEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatUnbanModerationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatUnbanModerationEvent extends EventSubChannelBaseModerationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelSharedChatUnbanModerationEventData;
+
+	override readonly moderationAction = 'shared_chat_unban';
+
+	/**
+	 * The ID of the user being unbanned.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].shared_chat_unban.user_id;
+	}
+
+	/**
+	 * The name of the user being unbanned.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].shared_chat_unban.user_login;
+	}
+
+	/**
+	 * The display name of the user being unbanned.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_unban.user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser | null> {
+		return await this._client.users.getUserById(this[rawDataSymbol].shared_chat_unban.user_id);
+	}
+}

--- a/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatUntimeoutModerationEvent.ts
+++ b/packages/eventsub-base/src/events/moderation/EventSubChannelSharedChatUntimeoutModerationEvent.ts
@@ -1,0 +1,46 @@
+import { rawDataSymbol, rtfm } from '@twurple/common';
+import { EventSubChannelBaseModerationEvent } from './EventSubChannelBaseModerationEvent';
+import { type EventSubChannelSharedChatUntimeoutModerationEventData } from './EventSubChannelModerationEvent.external';
+import type { HelixUser } from '@twurple/api';
+
+/**
+ * An EventSub event representing a moderator untimming out a user in another channel during a shared chat session.
+ */
+@rtfm<EventSubChannelSharedChatUntimeoutModerationEvent>(
+	'eventsub-base',
+	'EventSubChannelSharedChatUntimeoutModerationEvent',
+	'broadcasterId',
+)
+export class EventSubChannelSharedChatUntimeoutModerationEvent extends EventSubChannelBaseModerationEvent {
+	/** @internal */ declare readonly [rawDataSymbol]: EventSubChannelSharedChatUntimeoutModerationEventData;
+
+	override readonly moderationAction = 'shared_chat_untimeout';
+
+	/**
+	 * The ID of the user being untimed out.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].shared_chat_untimeout.user_id;
+	}
+
+	/**
+	 * The name of the user being untimed out.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].shared_chat_untimeout.user_login;
+	}
+
+	/**
+	 * The display name of the user being untimed out.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].shared_chat_untimeout.user_name;
+	}
+
+	/**
+	 * Gets more information about the user.
+	 */
+	async getUser(): Promise<HelixUser | null> {
+		return await this._client.users.getUserById(this[rawDataSymbol].shared_chat_untimeout.user_id);
+	}
+}

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -69,6 +69,11 @@ export { EventSubChannelRaidModerationEvent } from './events/moderation/EventSub
 export { EventSubChannelUnraidModerationEvent } from './events/moderation/EventSubChannelUnraidModerationEvent';
 export { EventSubChannelAutoModTermsModerationEvent } from './events/moderation/EventSubChannelAutoModTermsModerationEvent';
 export { EventSubChannelUnbanRequestModerationEvent } from './events/moderation/EventSubChannelUnbanRequestModerationEvent';
+export { EventSubChannelSharedChatBanModerationEvent } from './events/moderation/EventSubChannelSharedChatBanModerationEvent';
+export { EventSubChannelSharedChatUnbanModerationEvent } from './events/moderation/EventSubChannelSharedChatUnbanModerationEvent';
+export { EventSubChannelSharedChatTimeoutModerationEvent } from './events/moderation/EventSubChannelSharedChatTimeoutModerationEvent';
+export { EventSubChannelSharedChatUntimeoutModerationEvent } from './events/moderation/EventSubChannelSharedChatUntimeoutModerationEvent';
+export { EventSubChannelSharedChatDeleteModerationEvent } from './events/moderation/EventSubChannelSharedChatDeleteModerationEvent';
 export type { EventSubChannelModerationEvent } from './events/moderation/EventSubChannelModerationEvent';
 export type {
 	EventSubChannelModerationAction,

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -106,6 +106,9 @@ export { EventSubChannelRedemptionUpdateEvent } from './events/EventSubChannelRe
 export { EventSubChannelRewardEvent } from './events/EventSubChannelRewardEvent';
 export { EventSubChannelAutomaticRewardRedemptionAddEvent } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent';
 export type { EventSubAutomaticRewardType } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent.external';
+export { EventSubChannelSharedChatSessionBeginEvent } from './events/EventSubChannelSharedChatSessionBeginEvent';
+export { EventSubChannelSharedChatSessionUpdateEvent } from './events/EventSubChannelSharedChatSessionUpdateEvent';
+export { EventSubChannelSharedChatSessionEndEvent } from './events/EventSubChannelSharedChatSessionEndEvent';
 export { EventSubChannelShieldModeBeginEvent } from './events/EventSubChannelShieldModeBeginEvent';
 export { EventSubChannelShieldModeEndEvent } from './events/EventSubChannelShieldModeEndEvent';
 export { EventSubChannelShoutoutCreateEvent } from './events/EventSubChannelShoutoutCreateEvent';
@@ -162,5 +165,6 @@ export type { EventSubChannelPredictionColor } from './events/common/EventSubCha
 export { EventSubChannelPredictionOutcome } from './events/common/EventSubChannelPredictionOutcome';
 export { EventSubChannelPredictionPredictor } from './events/common/EventSubChannelPredictionPredictor';
 export type { EventSubChannelSuspiciousUserLowTrustStatus } from './events/common/EventSubChannelSuspiciousUserLowTrustStatus';
+export { EventSubChannelSharedChatSessionParticipant } from './events/common/EventSubChannelSharedChatSessionParticipant';
 
 export { EventSubSubscription } from './subscriptions/EventSubSubscription';

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -16,6 +16,24 @@ export { EventSubChannelChatClearEvent } from './events/EventSubChannelChatClear
 export { EventSubChannelChatClearUserMessagesEvent } from './events/EventSubChannelChatClearUserMessagesEvent';
 export { EventSubChannelChatMessageDeleteEvent } from './events/EventSubChannelChatMessageDeleteEvent';
 export { EventSubChannelChatMessageEvent } from './events/EventSubChannelChatMessageEvent';
+
+export {
+	type EventSubChannelChatNotificationType,
+	type EventSubChannelChatNotificationSubTier,
+	type EventSubChannelChatAnnouncementColor,
+} from './events/chatNotifications/EventSubChannelChatNotificationEvent.external';
+export { EventSubChannelChatSubNotificationEvent } from './events/chatNotifications/EventSubChannelChatSubNotificationEvent';
+export { EventSubChannelChatResubNotificationEvent } from './events/chatNotifications/EventSubChannelChatResubNotificationEvent';
+export { EventSubChannelChatSubGiftNotificationEvent } from './events/chatNotifications/EventSubChannelChatSubGiftNotificationEvent';
+export { EventSubChannelChatCommunitySubGiftNotificationEvent } from './events/chatNotifications/EventSubChannelChatCommunitySubGiftNotificationEvent';
+export { EventSubChannelChatGiftPaidUpgradeNotificationEvent } from './events/chatNotifications/EventSubChannelChatGiftPaidUpgradeNotificationEvent';
+export { EventSubChannelChatPrimePaidUpgradeNotificationEvent } from './events/chatNotifications/EventSubChannelChatPrimePaidUpgradeNotificationEvent';
+export { EventSubChannelChatRaidNotificationEvent } from './events/chatNotifications/EventSubChannelChatRaidNotificationEvent';
+export { EventSubChannelChatUnraidNotificationEvent } from './events/chatNotifications/EventSubChannelChatUnraidNotificationEvent';
+export { EventSubChannelChatPayItForwardNotificationEvent } from './events/chatNotifications/EventSubChannelChatPayItForwardNotificationEvent';
+export { EventSubChannelChatAnnouncementNotificationEvent } from './events/chatNotifications/EventSubChannelChatAnnouncementNotificationEvent';
+export { EventSubChannelChatCharityDonationNotificationEvent } from './events/chatNotifications/EventSubChannelChatCharityDonationNotificationEvent';
+export { EventSubChannelChatBitsBadgeTierNotificationEvent } from './events/chatNotifications/EventSubChannelChatBitsBadgeTierNotificationEvent';
 export type { EventSubChannelChatNotificationEvent } from './events/chatNotifications/EventSubChannelChatNotificationEvent';
 
 export { EventSubChannelBanModerationEvent } from './events/moderation/EventSubChannelBanModerationEvent';

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -34,6 +34,15 @@ export { EventSubChannelChatPayItForwardNotificationEvent } from './events/chatN
 export { EventSubChannelChatAnnouncementNotificationEvent } from './events/chatNotifications/EventSubChannelChatAnnouncementNotificationEvent';
 export { EventSubChannelChatCharityDonationNotificationEvent } from './events/chatNotifications/EventSubChannelChatCharityDonationNotificationEvent';
 export { EventSubChannelChatBitsBadgeTierNotificationEvent } from './events/chatNotifications/EventSubChannelChatBitsBadgeTierNotificationEvent';
+export { EventSubChannelChatSharedChatSubNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatSubNotificationEvent';
+export { EventSubChannelChatSharedChatResubNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatResubNotificationEvent';
+export { EventSubChannelChatSharedChatSubGiftNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatSubGiftNotificationEvent';
+export { EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent';
+export { EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent';
+export { EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent';
+export { EventSubChannelChatSharedChatPayItForwardNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatPayItForwardNotificationEvent';
+export { EventSubChannelChatSharedChatRaidNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatRaidNotificationEvent';
+export { EventSubChannelChatSharedChatAnnouncementNotificationEvent } from './events/chatNotifications/EventSubChannelChatSharedChatAnnouncementNotificationEvent';
 export type { EventSubChannelChatNotificationEvent } from './events/chatNotifications/EventSubChannelChatNotificationEvent';
 
 export { EventSubChannelBanModerationEvent } from './events/moderation/EventSubChannelBanModerationEvent';

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelChatNotificationSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelChatNotificationSubscription.ts
@@ -16,6 +16,15 @@ import { EventSubChannelChatSubNotificationEvent } from '../events/chatNotificat
 import { EventSubChannelChatUnraidNotificationEvent } from '../events/chatNotifications/EventSubChannelChatUnraidNotificationEvent';
 import type { EventSubBase } from '../EventSubBase';
 import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubChannelChatSharedChatSubNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatSubNotificationEvent';
+import { EventSubChannelChatSharedChatResubNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatResubNotificationEvent';
+import { EventSubChannelChatSharedChatSubGiftNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatSubGiftNotificationEvent';
+import { EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent';
+import { EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent';
+import { EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent';
+import { EventSubChannelChatSharedChatPayItForwardNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatPayItForwardNotificationEvent';
+import { EventSubChannelChatSharedChatAnnouncementNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatAnnouncementNotificationEvent';
+import { EventSubChannelChatSharedChatRaidNotificationEvent } from '../events/chatNotifications/EventSubChannelChatSharedChatRaidNotificationEvent';
 
 /** @internal */
 @rtfm('eventsub-base', 'EventSubSubscription')
@@ -43,28 +52,73 @@ export class EventSubChannelChatNotificationSubscription extends EventSubSubscri
 		switch (data.notice_type) {
 			case 'sub':
 				return new EventSubChannelChatSubNotificationEvent(data, this._client._apiClient);
+
 			case 'resub':
 				return new EventSubChannelChatResubNotificationEvent(data, this._client._apiClient);
+
 			case 'sub_gift':
 				return new EventSubChannelChatSubGiftNotificationEvent(data, this._client._apiClient);
+
 			case 'community_sub_gift':
 				return new EventSubChannelChatCommunitySubGiftNotificationEvent(data, this._client._apiClient);
+
 			case 'gift_paid_upgrade':
 				return new EventSubChannelChatGiftPaidUpgradeNotificationEvent(data, this._client._apiClient);
+
 			case 'prime_paid_upgrade':
 				return new EventSubChannelChatPrimePaidUpgradeNotificationEvent(data, this._client._apiClient);
+
 			case 'raid':
 				return new EventSubChannelChatRaidNotificationEvent(data, this._client._apiClient);
+
 			case 'unraid':
 				return new EventSubChannelChatUnraidNotificationEvent(data, this._client._apiClient);
+
 			case 'pay_it_forward':
 				return new EventSubChannelChatPayItForwardNotificationEvent(data, this._client._apiClient);
+
 			case 'announcement':
 				return new EventSubChannelChatAnnouncementNotificationEvent(data, this._client._apiClient);
+
 			case 'charity_donation':
 				return new EventSubChannelChatCharityDonationNotificationEvent(data, this._client._apiClient);
+
 			case 'bits_badge_tier':
 				return new EventSubChannelChatBitsBadgeTierNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_sub':
+				return new EventSubChannelChatSharedChatSubNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_resub':
+				return new EventSubChannelChatSharedChatResubNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_sub_gift':
+				return new EventSubChannelChatSharedChatSubGiftNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_community_sub_gift':
+				return new EventSubChannelChatSharedChatCommunitySubGiftNotificationEvent(
+					data,
+					this._client._apiClient,
+				);
+
+			case 'shared_chat_gift_paid_upgrade':
+				return new EventSubChannelChatSharedChatGiftPaidUpgradeNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_prime_paid_upgrade':
+				return new EventSubChannelChatSharedChatPrimePaidUpgradeNotificationEvent(
+					data,
+					this._client._apiClient,
+				);
+
+			case 'shared_chat_pay_it_forward':
+				return new EventSubChannelChatSharedChatPayItForwardNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_raid':
+				return new EventSubChannelChatSharedChatRaidNotificationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_announcement':
+				return new EventSubChannelChatSharedChatAnnouncementNotificationEvent(data, this._client._apiClient);
+
 			default:
 				throw new Error(
 					`Unknown chat notification type: ${(data as EventSubChannelChatNotificationEventData).notice_type}`,

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelModerateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelModerateSubscription.ts
@@ -29,6 +29,11 @@ import { EventSubChannelUnmodModerationEvent } from '../events/moderation/EventS
 import { EventSubChannelVipModerationEvent } from '../events/moderation/EventSubChannelVipModerationEvent';
 import { EventSubChannelUnvipModerationEvent } from '../events/moderation/EventSubChannelUnvipModerationEvent';
 import { EventSubChannelWarnModerationEvent } from '../events/moderation/EventSubChannelWarnModerationEvent';
+import { EventSubChannelSharedChatDeleteModerationEvent } from '../events/moderation/EventSubChannelSharedChatDeleteModerationEvent';
+import { EventSubChannelSharedChatBanModerationEvent } from '../events/moderation/EventSubChannelSharedChatBanModerationEvent';
+import { EventSubChannelSharedChatTimeoutModerationEvent } from '../events/moderation/EventSubChannelSharedChatTimeoutModerationEvent';
+import { EventSubChannelSharedChatUnbanModerationEvent } from '../events/moderation/EventSubChannelSharedChatUnbanModerationEvent';
+import { EventSubChannelSharedChatUntimeoutModerationEvent } from '../events/moderation/EventSubChannelSharedChatUntimeoutModerationEvent';
 
 /** @internal */
 @rtfm('eventsub-base', 'EventSubSubscription')
@@ -132,6 +137,21 @@ export class EventSubChannelModerateSubscription extends EventSubSubscription<Ev
 			case 'approve_unban_request':
 			case 'deny_unban_request':
 				return new EventSubChannelUnbanRequestModerationEvent(data, data.action, this._client._apiClient);
+
+			case 'shared_chat_ban':
+				return new EventSubChannelSharedChatBanModerationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_unban':
+				return new EventSubChannelSharedChatUnbanModerationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_timeout':
+				return new EventSubChannelSharedChatTimeoutModerationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_untimeout':
+				return new EventSubChannelSharedChatUntimeoutModerationEvent(data, this._client._apiClient);
+
+			case 'shared_chat_delete':
+				return new EventSubChannelSharedChatDeleteModerationEvent(data, this._client._apiClient);
 
 			default:
 				throw new Error(

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelSharedChatSessionBeginSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelSharedChatSessionBeginSubscription.ts
@@ -1,0 +1,41 @@
+import { rtfm } from '@twurple/common';
+import type { HelixEventSubSubscription } from '@twurple/api';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { type EventSubChannelSharedChatSessionBeginEventData } from '../events/EventSubChannelSharedChatSessionBeginEvent.external';
+import { EventSubChannelSharedChatSessionBeginEvent } from '../events/EventSubChannelSharedChatSessionBeginEvent';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelSharedChatSessionBeginSubscription extends EventSubSubscription<EventSubChannelSharedChatSessionBeginEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubChannelSharedChatSessionBeginEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.shared_chat.begin.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelSharedChatSessionBeginEventData,
+	): EventSubChannelSharedChatSessionBeginEvent {
+		return new EventSubChannelSharedChatSessionBeginEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelSharedChatSessionBeginEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelSharedChatSessionEndSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelSharedChatSessionEndSubscription.ts
@@ -1,0 +1,41 @@
+import { rtfm } from '@twurple/common';
+import type { HelixEventSubSubscription } from '@twurple/api';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { type EventSubChannelSharedChatSessionEndEventData } from '../events/EventSubChannelSharedChatSessionEndEvent.external';
+import { EventSubChannelSharedChatSessionEndEvent } from '../events/EventSubChannelSharedChatSessionEndEvent';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelSharedChatSessionEndSubscription extends EventSubSubscription<EventSubChannelSharedChatSessionEndEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubChannelSharedChatSessionEndEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.shared_chat.end.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelSharedChatSessionEndEventData,
+	): EventSubChannelSharedChatSessionEndEvent {
+		return new EventSubChannelSharedChatSessionEndEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelSharedChatSessionEndEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelSharedChatSessionUpdateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelSharedChatSessionUpdateSubscription.ts
@@ -1,0 +1,41 @@
+import { rtfm } from '@twurple/common';
+import type { HelixEventSubSubscription } from '@twurple/api';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { type EventSubChannelSharedChatSessionUpdateEventData } from '../events/EventSubChannelSharedChatSessionUpdateEvent.external';
+import { EventSubChannelSharedChatSessionUpdateEvent } from '../events/EventSubChannelSharedChatSessionUpdateEvent';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelSharedChatSessionUpdateSubscription extends EventSubSubscription<EventSubChannelSharedChatSessionUpdateEvent> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubChannelSharedChatSessionUpdateEvent) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.shared_chat.update.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelSharedChatSessionUpdateEventData,
+	): EventSubChannelSharedChatSessionUpdateEvent {
+		return new EventSubChannelSharedChatSessionUpdateEvent(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelSharedChatSessionUpdateEvents(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}


### PR DESCRIPTION
Type: Feature
Fixes: #601

This is a blind implementation based only on the API specs. I found it hard to test these features myself. 

1. I can confirm successful response `200` calling [Get Shared Chat Session](https://dev.twitch.tv/docs/api/reference/#get-shared-chat-session) endpoint with an empty result.
2. I can confirm successful subscription `202` to [channel.shared_chat.begin](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelshared_chatbegin), [channel.shared_chat.update](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelshared_chatupdate), and [channel.shared_chat.end](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelshared_chatend).

Nothing else has been tested.