### PR TITLE
fix: harden eventsub signature verification

### DIFF
--- a/packages/eventsub-http/src/EventSubHttpBase.ts
+++ b/packages/eventsub-http/src/EventSubHttpBase.ts
@@ -349,11 +349,12 @@ export abstract class EventSubHttpBase extends EventSubBase {
 	private _verifyData(messageId: string, timestamp: string, body: string, algoAndSignature: string): boolean {
 		const [algorithm, signature] = algoAndSignature.split('=', 2);
 
+		const expected = Buffer.from(signature, 'hex');
 		const hash = crypto
 			.createHmac(algorithm, this._secret)
 			.update(messageId + timestamp + body)
-			.digest('hex');
+			.digest();
 
-		return hash === signature;
+		return hash.length === expected.length && crypto.timingSafeEqual(hash, expected);
 	}
 }

--- a/packages/eventsub-http/src/EventSubHttpBase.ts
+++ b/packages/eventsub-http/src/EventSubHttpBase.ts
@@ -347,11 +347,15 @@ export abstract class EventSubHttpBase extends EventSubBase {
 
 	/** @internal */
 	private _verifyData(messageId: string, timestamp: string, body: string, algoAndSignature: string): boolean {
-		const [algorithm, signature] = algoAndSignature.split('=', 2);
+		const signaturePrefix = 'sha256=';
+		if (!algoAndSignature.startsWith(signaturePrefix)) {
+			return false;
+		}
 
+		const signature = algoAndSignature.substring(signaturePrefix.length);
 		const expected = Buffer.from(signature, 'hex');
 		const hash = crypto
-			.createHmac(algorithm, this._secret)
+			.createHmac('sha256', this._secret)
 			.update(messageId + timestamp + body)
 			.digest();
 


### PR DESCRIPTION
Type: Bugfix/Improvement

Force `sha256` hmac to avoid algorithm downgrade and use `timingSafeEqual` to avoid timing attacks

Prevents notification forgery and secret key recovery (which would require node <17 or `--openssl-legacy-provider` for MD4 usage, and an extremely unrealistic number of http requests)
