### PR TITLE
Feat: Upgrade EventSub channel update event to v2

### DIFF
--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -337,7 +337,7 @@ export class HelixEventSubApi extends BaseApi {
 	): Promise<HelixEventSubSubscription> {
 		return await this.createSubscription(
 			'channel.update',
-			'1',
+			'2',
 			createEventSubBroadcasterCondition(broadcaster),
 			transport,
 			broadcaster,

--- a/packages/eventsub-base/src/events/EventSubChannelUpdateEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelUpdateEvent.external.ts
@@ -7,5 +7,5 @@ export interface EventSubChannelUpdateEventData {
 	language: string;
 	category_id: string;
 	category_name: string;
-	is_mature: boolean;
+	content_classification_labels: string[];
 }

--- a/packages/eventsub-base/src/events/EventSubChannelUpdateEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelUpdateEvent.ts
@@ -83,8 +83,24 @@ export class EventSubChannelUpdateEvent extends DataObject<EventSubChannelUpdate
 
 	/**
 	 * Whether the channel is flagged as suitable for mature audiences only.
+	 *
+	 * @deprecated Use {@link EventSubChannelUpdateEvent#contentClassificationLabels} to check if any content
+	 * classification labels are applied to the channel.
+	 *
+	 * Currently, this flag mimics the previous behavior by checking whether the `contentClassificationLabels`
+	 * array is not empty.
+	 *
+	 * This flag will be removed in the next major release.
 	 */
 	get isMature(): boolean {
-		return this[rawDataSymbol].is_mature;
+		return this[rawDataSymbol].content_classification_labels.length > 0;
+	}
+
+	/**
+	 * An array of content classification label IDs currently applied on the channel.
+	 * To retrieve a list of all possible IDs, use the {@link ApiClient#contentClassificationLabels#getAll} API method.
+	 */
+	get contentClassificationLabels(): string[] {
+		return this[rawDataSymbol].content_classification_labels;
 	}
 }

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelUpdateSubscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelUpdateSubscription.ts
@@ -19,7 +19,7 @@ export class EventSubChannelUpdateSubscription extends EventSubSubscription<Even
 	}
 
 	get id(): string {
-		return `channel.update.${this._userId}`;
+		return `channel.update.v2.${this._userId}`;
 	}
 
 	get authUserId(): string | null {


### PR DESCRIPTION
Type: Feature
Fixes: 

Switched `channel.update` subscription to version 2 and updated event data structure. Added `contentClassificationLabels` accessor and marked `isMature` flag as deprecated, mimicking its previous behavior.