### PR TITLE
Feat: Add EventSub automatic reward redemption v2

### DIFF
--- a/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
+++ b/packages/api/src/endpoints/eventSub/HelixEventSubApi.ts
@@ -917,6 +917,26 @@ export class HelixEventSubApi extends BaseApi {
 	}
 
 	/**
+	 * Subscribe to events that represent a Channel Points automatic reward being redeemed.
+	 *
+	 * @param broadcaster The broadcaster you want to listen to automatic reward redemption events for.
+	 * @param transport The transport options.
+	 */
+	async subscribeToChannelAutomaticRewardRedemptionAddV2Events(
+		broadcaster: UserIdResolvable,
+		transport: HelixEventSubTransportOptions,
+	): Promise<HelixEventSubSubscription> {
+		return await this.createSubscription(
+			'channel.channel_points_automatic_reward_redemption.add',
+			'2',
+			createEventSubBroadcasterCondition(broadcaster),
+			transport,
+			broadcaster,
+			['channel:read:redemptions', 'channel:manage:redemptions'],
+		);
+	}
+
+	/**
 	 * Subscribe to events that represent a poll starting in a channel.
 	 *
 	 * @param broadcaster The broadcaster you want to listen to poll begin events for.

--- a/packages/eventsub-base/src/EventSubBase.ts
+++ b/packages/eventsub-base/src/EventSubBase.ts
@@ -53,6 +53,7 @@ import type { EventSubChannelRedemptionAddEvent } from './events/EventSubChannel
 import type { EventSubChannelRedemptionUpdateEvent } from './events/EventSubChannelRedemptionUpdateEvent';
 import type { EventSubChannelRewardEvent } from './events/EventSubChannelRewardEvent';
 import type { EventSubChannelAutomaticRewardRedemptionAddEvent } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent';
+import { type EventSubChannelAutomaticRewardRedemptionAddV2Event } from './events/EventSubChannelAutomaticRewardRedemptionAddV2Event';
 import { type EventSubChannelSharedChatSessionBeginEvent } from './events/EventSubChannelSharedChatSessionBeginEvent';
 import { type EventSubChannelSharedChatSessionUpdateEvent } from './events/EventSubChannelSharedChatSessionUpdateEvent';
 import { type EventSubChannelSharedChatSessionEndEvent } from './events/EventSubChannelSharedChatSessionEndEvent';
@@ -126,6 +127,7 @@ import { EventSubChannelRewardAddSubscription } from './subscriptions/EventSubCh
 import { EventSubChannelRewardRemoveSubscription } from './subscriptions/EventSubChannelRewardRemoveSubscription';
 import { EventSubChannelRewardUpdateSubscription } from './subscriptions/EventSubChannelRewardUpdateSubscription';
 import { EventSubChannelAutomaticRewardRedemptionAddSubscription } from './subscriptions/EventSubChannelAutomaticRewardRedemptionAddSubscription';
+import { EventSubChannelAutomaticRewardRedemptionAddV2Subscription } from './subscriptions/EventSubChannelAutomaticRewardRedemptionAddV2Subscription';
 import { EventSubChannelSharedChatSessionBeginSubscription } from './subscriptions/EventSubChannelSharedChatSessionBeginSubscription';
 import { EventSubChannelSharedChatSessionUpdateSubscription } from './subscriptions/EventSubChannelSharedChatSessionUpdateSubscription';
 import { EventSubChannelSharedChatSessionEndSubscription } from './subscriptions/EventSubChannelSharedChatSessionEndSubscription';
@@ -796,6 +798,21 @@ export abstract class EventSubBase extends EventEmitter {
 		const userId = this._extractUserIdWithNumericWarning(user, 'onChannelAutomaticRewardRedemptionAdd');
 
 		return this._genericSubscribe(EventSubChannelAutomaticRewardRedemptionAddSubscription, handler, this, userId);
+	}
+
+	/**
+	 * Subscribes to events that represent a specific Channel Points automatic reward being redeemed.
+	 *
+	 * @param user The user for which to get notifications when their automatic reward is redeemed.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelAutomaticRewardRedemptionAddV2(
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelAutomaticRewardRedemptionAddV2Event) => void,
+	): EventSubSubscription {
+		const userId = this._extractUserIdWithNumericWarning(user, 'onChannelAutomaticRewardRedemptionAddV2');
+
+		return this._genericSubscribe(EventSubChannelAutomaticRewardRedemptionAddV2Subscription, handler, this, userId);
 	}
 
 	/**

--- a/packages/eventsub-base/src/EventSubListener.ts
+++ b/packages/eventsub-base/src/EventSubListener.ts
@@ -42,6 +42,7 @@ import type { EventSubChannelRedemptionAddEvent } from './events/EventSubChannel
 import type { EventSubChannelRedemptionUpdateEvent } from './events/EventSubChannelRedemptionUpdateEvent';
 import type { EventSubChannelRewardEvent } from './events/EventSubChannelRewardEvent';
 import type { EventSubChannelAutomaticRewardRedemptionAddEvent } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent';
+import { type EventSubChannelAutomaticRewardRedemptionAddV2Event } from './events/EventSubChannelAutomaticRewardRedemptionAddV2Event';
 import type { EventSubChannelShieldModeBeginEvent } from './events/EventSubChannelShieldModeBeginEvent';
 import type { EventSubChannelShieldModeEndEvent } from './events/EventSubChannelShieldModeEndEvent';
 import type { EventSubChannelShoutoutCreateEvent } from './events/EventSubChannelShoutoutCreateEvent';
@@ -436,6 +437,17 @@ export interface EventSubListener {
 	onChannelAutomaticRewardRedemptionAdd: (
 		user: UserIdResolvable,
 		handler: (data: EventSubChannelAutomaticRewardRedemptionAddEvent) => void,
+	) => EventSubSubscription;
+
+	/**
+	 * Subscribes to events that represent a specific Channel Points automatic reward being redeemed.
+	 *
+	 * @param user The user for which to get notifications when their automatic reward is redeemed.
+	 * @param handler The function that will be called for any new notifications.
+	 */
+	onChannelAutomaticRewardRedemptionAddV2: (
+		user: UserIdResolvable,
+		handler: (data: EventSubChannelAutomaticRewardRedemptionAddV2Event) => void,
 	) => EventSubSubscription;
 
 	/**

--- a/packages/eventsub-base/src/events/EventSubChannelAutomaticRewardRedemptionAddV2Event.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelAutomaticRewardRedemptionAddV2Event.external.ts
@@ -1,0 +1,44 @@
+import { type EventSubChannelAutomaticRewardData } from './common/EventSubChannelAutomaticReward.external';
+
+/** @private */
+export interface EventSubChatAutomaticRewardRedemptionMessageTextPart {
+	type: 'text';
+	text: string;
+}
+
+/** @private */
+export interface EventSubChatAutomaticRewardRedemptionMessageEmoteData {
+	id: string;
+}
+
+/** @private */
+export interface EventSubChatAutomaticRewardRedemptionMessageEmotePart {
+	type: 'emote';
+	text: string;
+	emote: EventSubChatAutomaticRewardRedemptionMessageEmoteData;
+}
+
+/** @private */
+export type EventSubAutomaticRewardRedemptionMessagePart =
+	| EventSubChatAutomaticRewardRedemptionMessageTextPart
+	| EventSubChatAutomaticRewardRedemptionMessageEmotePart;
+
+/** @private */
+export interface EventSubChatAutomaticRewardRedemptionMessageData {
+	text: string;
+	fragments: EventSubAutomaticRewardRedemptionMessagePart[];
+}
+
+/** @private */
+export interface EventSubChannelAutomaticRewardRedemptionAddV2EventData {
+	broadcaster_user_id: string;
+	broadcaster_user_name: string;
+	broadcaster_user_login: string;
+	user_id: string;
+	user_name: string;
+	user_login: string;
+	id: string;
+	reward: EventSubChannelAutomaticRewardData;
+	message: EventSubChatAutomaticRewardRedemptionMessageData | null;
+	redeemed_at: string;
+}

--- a/packages/eventsub-base/src/events/EventSubChannelAutomaticRewardRedemptionAddV2Event.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelAutomaticRewardRedemptionAddV2Event.ts
@@ -1,0 +1,117 @@
+import { Enumerable } from '@d-fischer/shared-utils';
+import type { ApiClient, HelixUser } from '@twurple/api';
+import { checkRelationAssertion, DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import {
+	type EventSubAutomaticRewardRedemptionMessagePart,
+	type EventSubChannelAutomaticRewardRedemptionAddV2EventData,
+} from './EventSubChannelAutomaticRewardRedemptionAddV2Event.external';
+import { EventSubChannelAutomaticReward } from './common/EventSubChannelAutomaticReward';
+
+/**
+ * An EventSub event representing an automatic reward being redeemed by a user in a channel.
+ */
+@rtfm<EventSubChannelAutomaticRewardRedemptionAddV2Event>(
+	'eventsub-base',
+	'EventSubChannelAutomaticRewardRedemptionAddV2Event',
+	'id',
+)
+export class EventSubChannelAutomaticRewardRedemptionAddV2Event extends DataObject<EventSubChannelAutomaticRewardRedemptionAddV2EventData> {
+	/** @internal */ @Enumerable(false) private readonly _client: ApiClient;
+
+	/** @internal */
+	constructor(data: EventSubChannelAutomaticRewardRedemptionAddV2EventData, client: ApiClient) {
+		super(data);
+		this._client = client;
+	}
+
+	/**
+	 * The ID of the redemption.
+	 */
+	get id(): string {
+		return this[rawDataSymbol].id;
+	}
+
+	/**
+	 * The ID of the broadcaster in whose channel the reward was redeemed.
+	 */
+	get broadcasterId(): string {
+		return this[rawDataSymbol].broadcaster_user_id;
+	}
+
+	/**
+	 * The name of the broadcaster in whose channel the reward was redeemed.
+	 */
+	get broadcasterName(): string {
+		return this[rawDataSymbol].broadcaster_user_login;
+	}
+
+	/**
+	 * The display name of the broadcaster in whose channel the reward was redeemed.
+	 */
+	get broadcasterDisplayName(): string {
+		return this[rawDataSymbol].broadcaster_user_name;
+	}
+
+	/**
+	 * Gets more information about the broadcaster.
+	 */
+	async getBroadcaster(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].broadcaster_user_id));
+	}
+
+	/**
+	 * The ID of the redeeming user.
+	 */
+	get userId(): string {
+		return this[rawDataSymbol].user_id;
+	}
+
+	/**
+	 * The name of the redeeming user.
+	 */
+	get userName(): string {
+		return this[rawDataSymbol].user_login;
+	}
+
+	/**
+	 * The display name of the redeeming user.
+	 */
+	get userDisplayName(): string {
+		return this[rawDataSymbol].user_name;
+	}
+
+	/**
+	 * Gets more information about the redeeming user.
+	 */
+	async getUser(): Promise<HelixUser> {
+		return checkRelationAssertion(await this._client.users.getUserById(this[rawDataSymbol].user_id));
+	}
+
+	/**
+	 * An object that contains the reward information.
+	 */
+	get reward(): EventSubChannelAutomaticReward {
+		return new EventSubChannelAutomaticReward(this[rawDataSymbol].reward);
+	}
+
+	/**
+	 * The text of the message, or `null` if there is no message.
+	 */
+	get messageText(): string | null {
+		return this[rawDataSymbol].message?.text ?? null;
+	}
+
+	/**
+	 * The pre-parsed message parts.
+	 */
+	get messageParts(): EventSubAutomaticRewardRedemptionMessagePart[] {
+		return this[rawDataSymbol].message?.fragments ?? [];
+	}
+
+	/**
+	 * The date when the user redeemed the reward.
+	 */
+	get redemptionDate(): Date | null {
+		return new Date(this[rawDataSymbol].redeemed_at);
+	}
+}

--- a/packages/eventsub-base/src/events/common/EventSubChannelAutomaticReward.external.ts
+++ b/packages/eventsub-base/src/events/common/EventSubChannelAutomaticReward.external.ts
@@ -1,0 +1,24 @@
+/**
+ * The type of the reward.
+ */
+export type EventSubChannelAutomaticRewardType =
+	| 'single_message_bypass_sub_mode'
+	| 'send_highlighted_message'
+	| 'random_sub_emote_unlock'
+	| 'chosen_sub_emote_unlock'
+	| 'chosen_modified_sub_emote_unlock';
+
+/**
+ * Emote associated with the reward.
+ */
+export interface EventSubChannelAutomaticRewardEmoteData {
+	id: string;
+	name: string;
+}
+
+/** @private*/
+export interface EventSubChannelAutomaticRewardData {
+	type: EventSubChannelAutomaticRewardType;
+	channel_points: number;
+	emote: EventSubChannelAutomaticRewardEmoteData | null;
+}

--- a/packages/eventsub-base/src/events/common/EventSubChannelAutomaticReward.ts
+++ b/packages/eventsub-base/src/events/common/EventSubChannelAutomaticReward.ts
@@ -1,0 +1,33 @@
+import { DataObject, rawDataSymbol, rtfm } from '@twurple/common';
+import {
+	type EventSubChannelAutomaticRewardData,
+	type EventSubChannelAutomaticRewardEmoteData,
+	type EventSubChannelAutomaticRewardType,
+} from './EventSubChannelAutomaticReward.external';
+
+/**
+ * An object that contains the reward information.
+ */
+@rtfm('eventsub-base', 'EventSubChannelAutomaticReward')
+export class EventSubChannelAutomaticReward extends DataObject<EventSubChannelAutomaticRewardData> {
+	/**
+	 * The type of reward.
+	 */
+	get type(): EventSubChannelAutomaticRewardType {
+		return this[rawDataSymbol].type;
+	}
+
+	/**
+	 * Number of channel points used.
+	 */
+	get channelPoints(): number {
+		return this[rawDataSymbol].channel_points;
+	}
+
+	/**
+	 * Emote associated with the reward, or `null` if the reward is not related to emotes.
+	 */
+	get emote(): EventSubChannelAutomaticRewardEmoteData | null {
+		return this[rawDataSymbol].emote;
+	}
+}

--- a/packages/eventsub-base/src/index.ts
+++ b/packages/eventsub-base/src/index.ts
@@ -105,6 +105,7 @@ export { EventSubChannelRedemptionAddEvent } from './events/EventSubChannelRedem
 export { EventSubChannelRedemptionUpdateEvent } from './events/EventSubChannelRedemptionUpdateEvent';
 export { EventSubChannelRewardEvent } from './events/EventSubChannelRewardEvent';
 export { EventSubChannelAutomaticRewardRedemptionAddEvent } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent';
+export { EventSubChannelAutomaticRewardRedemptionAddV2Event } from './events/EventSubChannelAutomaticRewardRedemptionAddV2Event';
 export type { EventSubAutomaticRewardType } from './events/EventSubChannelAutomaticRewardRedemptionAddEvent.external';
 export { EventSubChannelSharedChatSessionBeginEvent } from './events/EventSubChannelSharedChatSessionBeginEvent';
 export { EventSubChannelSharedChatSessionUpdateEvent } from './events/EventSubChannelSharedChatSessionUpdateEvent';
@@ -154,6 +155,8 @@ export type {
 	EventSubChannelSuspiciousUserType,
 } from './events/EventSubChannelSuspiciousUserMessageEvent.external';
 
+export type { EventSubChannelAutomaticReward } from './events/common/EventSubChannelAutomaticReward';
+export type { EventSubChannelAutomaticRewardType } from './events/common/EventSubChannelAutomaticReward.external';
 export type { EventSubAutoModLevel } from './events/common/EventSubAutoModLevel';
 export type { EventSubAutoModMessageHoldReason } from './events/common/EventSubAutoModMessageHoldReason';
 export { EventSubAutoModMessageAutoMod } from './events/common/EventSubAutoModMessageAutoMod';

--- a/packages/eventsub-base/src/subscriptions/EventSubChannelAutomaticRewardRedemptionAddV2Subscription.ts
+++ b/packages/eventsub-base/src/subscriptions/EventSubChannelAutomaticRewardRedemptionAddV2Subscription.ts
@@ -1,0 +1,41 @@
+import type { HelixEventSubSubscription } from '@twurple/api';
+import { rtfm } from '@twurple/common';
+import type { EventSubBase } from '../EventSubBase';
+import { EventSubSubscription } from './EventSubSubscription';
+import { EventSubChannelAutomaticRewardRedemptionAddV2Event } from '../events/EventSubChannelAutomaticRewardRedemptionAddV2Event';
+import { type EventSubChannelAutomaticRewardRedemptionAddV2EventData } from '../events/EventSubChannelAutomaticRewardRedemptionAddV2Event.external';
+
+/** @internal */
+@rtfm('eventsub-base', 'EventSubSubscription')
+export class EventSubChannelAutomaticRewardRedemptionAddV2Subscription extends EventSubSubscription<EventSubChannelAutomaticRewardRedemptionAddV2Event> {
+	/** @protected */ readonly _cliName = '';
+
+	constructor(
+		handler: (data: EventSubChannelAutomaticRewardRedemptionAddV2Event) => void,
+		client: EventSubBase,
+		private readonly _userId: string,
+	) {
+		super(handler, client);
+	}
+
+	get id(): string {
+		return `channel.channel_points_automatic_reward_redemption.add.v2.${this._userId}`;
+	}
+
+	get authUserId(): string | null {
+		return this._userId;
+	}
+
+	protected transformData(
+		data: EventSubChannelAutomaticRewardRedemptionAddV2EventData,
+	): EventSubChannelAutomaticRewardRedemptionAddV2Event {
+		return new EventSubChannelAutomaticRewardRedemptionAddV2Event(data, this._client._apiClient);
+	}
+
+	protected async _subscribe(): Promise<HelixEventSubSubscription> {
+		return await this._client._apiClient.eventSub.subscribeToChannelAutomaticRewardRedemptionAddV2Events(
+			this._userId,
+			await this._getTransportOptions(),
+		);
+	}
+}


### PR DESCRIPTION
Type: Feature
Fixes: #619 

This implementation adds separate methods and classes for Automatic Reward Redemption V2, without replacing the existing V1 logic.

#### Testing

- ✅ Subscription confirmed working
- ❌ Events have not been tested
