### PR TITLE
Feat: Sorce only chat message

### DIFF
--- a/packages/api/src/endpoints/chat/HelixChatApi.ts
+++ b/packages/api/src/endpoints/chat/HelixChatApi.ts
@@ -3,6 +3,7 @@ import { extractUserId, rtfm, type UserIdResolvable } from '@twurple/common';
 import {
 	createChatColorUpdateQuery,
 	createChatSettingsUpdateBody,
+	createSendChatMessageAsAppBody,
 	createSendChatMessageBody,
 	createSendChatMessageQuery,
 	createShoutoutQuery,
@@ -20,6 +21,7 @@ import {
 } from '../../interfaces/endpoints/chat.external';
 import {
 	type HelixSendChatAnnouncementParams,
+	type HelixSendChatMessageAsAppParams,
 	type HelixSendChatMessageParams,
 	type HelixUpdateChatSettingsParams,
 	type HelixUserEmotesFilter,
@@ -380,7 +382,7 @@ export class HelixChatApi extends BaseApi {
 		user: UserIdResolvable,
 		broadcaster: UserIdResolvable,
 		message: string,
-		params?: HelixSendChatMessageParams,
+		params?: HelixSendChatMessageAsAppParams,
 	): Promise<HelixSentChatMessage> {
 		const userId = extractUserId(user);
 		const broadcasterId = extractUserId(broadcaster);
@@ -390,7 +392,7 @@ export class HelixChatApi extends BaseApi {
 			method: 'POST',
 			forceType: 'app',
 			query: createSendChatMessageQuery(broadcasterId, userId),
-			jsonBody: createSendChatMessageBody(message, params),
+			jsonBody: createSendChatMessageAsAppBody(message, params),
 		});
 
 		return new HelixSentChatMessage(result.data[0]);

--- a/packages/api/src/interfaces/endpoints/chat.external.ts
+++ b/packages/api/src/interfaces/endpoints/chat.external.ts
@@ -1,5 +1,9 @@
 import { extractUserId, type UserIdResolvable } from '@twurple/common';
-import { type HelixSendChatMessageParams, type HelixUpdateChatSettingsParams } from './chat.input';
+import {
+	type HelixSendChatMessageAsAppParams,
+	type HelixSendChatMessageParams,
+	type HelixUpdateChatSettingsParams,
+} from './chat.input';
 
 /**
  * The subscription tier necessary to unlock an emote. 1000 means tier 1, and so on.
@@ -195,5 +199,14 @@ export function createSendChatMessageBody(message: string, params: HelixSendChat
 	return {
 		message,
 		reply_parent_message_id: params?.replyParentMessageId,
+	};
+}
+
+/** @internal */
+export function createSendChatMessageAsAppBody(message: string, params: HelixSendChatMessageAsAppParams | undefined) {
+	return {
+		message,
+		reply_parent_message_id: params?.replyParentMessageId,
+		for_source_only: params?.forSourceOnly,
 	};
 }

--- a/packages/api/src/interfaces/endpoints/chat.input.ts
+++ b/packages/api/src/interfaces/endpoints/chat.input.ts
@@ -63,6 +63,19 @@ export interface HelixSendChatMessageParams {
 }
 
 /**
+ * A request to send a message to a broadcaster's chat with app access token.
+ */
+export interface HelixSendChatMessageAsAppParams extends HelixSendChatMessageParams {
+	/**
+	 * Specifies whether the chat message should be sent only to the source channel during a shared chat session.
+	 * This parameter has no effect if a shared chat session is not active.
+	 *
+	 * @default true
+	 */
+	forSourceOnly?: boolean;
+}
+
+/**
  * A request to send an announcement to a broadcaster's chat.
  */
 export interface HelixSendChatAnnouncementParams {

--- a/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.external.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.external.ts
@@ -44,4 +44,5 @@ export interface EventSubChannelChatMessageEventData {
 	source_broadcaster_user_name: string | null;
 	source_message_id: string | null;
 	source_badges: EventSubChatBadge[] | null;
+	is_source_only: boolean | null;
 }

--- a/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.ts
+++ b/packages/eventsub-base/src/events/EventSubChannelChatMessageEvent.ts
@@ -305,4 +305,12 @@ export class EventSubChannelChatMessageEvent extends DataObject<EventSubChannelC
 	getSourceBadgeInfo(name: string): string | null {
 		return this[rawDataSymbol].source_badges?.find(badge => badge.set_id === name)?.info ?? null;
 	}
+
+	/**
+	 * Determines if a message delivered during a shared chat session is only sent to the source channel.
+	 * Has no effect if the message is not sent during a shared chat session.
+	 */
+	get isSourceOnly(): boolean | null {
+		return this[rawDataSymbol].is_source_only;
+	}
 }


### PR DESCRIPTION
Type: Feature
Fixes: #636 

This feature has not been tested during a shared chat session. The field `isSourceOnly` is present in the payload as `null`. Sending a message using an app access token with `forSourceOnly` set has no effect. At least, no errors were received from EventSub or API.

